### PR TITLE
Implement password reset page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# startup-connect
+# Startup Connect
+
+A prototype platform for connecting entrepreneurs and business partners.
+
+## Password Reset
+
+If you forget your password, open [login.html](login.html) and use the "パスワードを忘れた場合" link. An email will be sent with a link to [reset-password.html](reset-password.html) where you can set a new password.

--- a/login.html
+++ b/login.html
@@ -522,7 +522,7 @@
             const { data, error } = await supabase.auth.resetPasswordForEmail(
               email,
               {
-                redirectTo: window.location.origin + "/reset-password.html",
+                redirectTo: `${window.location.origin}/reset-password.html`,
               }
             );
 

--- a/reset-password.html
+++ b/reset-password.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
+    <title>パスワードリセット - スタートアップコネクト</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="config.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <style>
+      body {
+        font-family: "Noto Sans JP", sans-serif;
+      }
+    </style>
+  </head>
+  <body class="bg-gray-50 flex items-center justify-center min-h-screen">
+    <div class="bg-white p-6 rounded-md shadow-md w-full max-w-md">
+      <h1 class="text-xl font-semibold mb-4">パスワードリセット</h1>
+      <p class="mb-4">新しいパスワードを入力してください。</p>
+      <div id="error-message" class="hidden mb-4 text-red-600">
+        <p id="error-text"></p>
+      </div>
+      <div id="success-message" class="hidden mb-4 text-green-600">
+        <p id="success-text"></p>
+      </div>
+      <form id="reset-password-form" class="space-y-4">
+        <input id="new-password" type="password" placeholder="新しいパスワード" class="w-full border rounded-md p-2" />
+        <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded-md">更新する</button>
+      </form>
+    </div>
+
+    <script>
+      const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
+      const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+      function showError(message) {
+        const errorDiv = document.getElementById('error-message');
+        const errorText = document.getElementById('error-text');
+        errorText.textContent = message;
+        errorDiv.classList.remove('hidden');
+        setTimeout(() => errorDiv.classList.add('hidden'), 5000);
+      }
+
+      function showSuccess(message) {
+        const successDiv = document.getElementById('success-message');
+        const successText = document.getElementById('success-text');
+        successText.textContent = message;
+        successDiv.classList.remove('hidden');
+      }
+
+      document.getElementById('reset-password-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const newPassword = document.getElementById('new-password').value;
+        if (!newPassword || newPassword.length < 6) {
+          showError('パスワードは6文字以上で入力してください。');
+          return;
+        }
+        const { error } = await supabase.auth.updateUser({ password: newPassword });
+        if (error) {
+          showError('パスワード更新に失敗しました: ' + error.message);
+        } else {
+          showSuccess('パスワードを更新しました。ログインページへリダイレクトします。');
+          setTimeout(() => {
+            window.location.href = 'login.html?message=password-reset';
+          }, 2000);
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone `reset-password.html` to handle Supabase password recovery
- update the password reset redirect in `login.html`
- document the reset flow in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685029537724833093b4a6a9b6246370