### PR TITLE
Add file size check for event images

### DIFF
--- a/events.html
+++ b/events.html
@@ -1350,6 +1350,13 @@
 
           try {
             const formData = new FormData(this);
+            const imageFile = formData.get("event-image");
+            if (imageFile && imageFile.size > 2 * 1024 * 1024) {
+              alert("画像ファイルは2MB以下にしてください。");
+              submitButton.disabled = false;
+              submitButton.textContent = "作成する";
+              return;
+            }
             await createEvent(formData);
 
             document


### PR DESCRIPTION
## Summary
- enforce 2MB limit when uploading event images in `events.html`

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850295b42a48330bc3591a39ad26218