### PR TITLE
Add event detail page

### DIFF
--- a/event-detail.html
+++ b/event-detail.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
+    <title>イベント - スタートアップコネクト</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="config.js"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        font-family: "Noto Sans JP", sans-serif;
+      }
+      .scrollbar-thin::-webkit-scrollbar {
+        width: 5px;
+      }
+      .scrollbar-thin::-webkit-scrollbar-track {
+        background: #f1f1f1;
+      }
+      .scrollbar-thin::-webkit-scrollbar-thumb {
+        background: #d1d5db;
+        border-radius: 5px;
+      }
+      .scrollbar-thin::-webkit-scrollbar-thumb:hover {
+        background: #9ca3af;
+      }
+      .skeleton {
+        animation: shimmer 1.5s infinite;
+        background: linear-gradient(
+          90deg,
+          #f0f0f0 25%,
+          #e0e0e0 50%,
+          #f0f0f0 75%
+        );
+        background-size: 200% 100%;
+      }
+      @keyframes shimmer {
+        0% {
+          background-position: 200% 0;
+        }
+        100% {
+          background-position: -200% 0;
+        }
+      }
+    </style>
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <header class="bg-white shadow-md sticky top-0 z-20">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between h-16">
+          <div class="flex items-center">
+            <div class="flex-shrink-0 flex items-center">
+              <a href="index.html">
+                <svg
+                  class="h-8 w-8 text-blue-600"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                  <circle cx="9" cy="7" r="4"></circle>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                </svg>
+              </a>
+              <a
+                href="dashboard.html"
+                class="ml-2 text-xl font-bold text-gray-800"
+                >スタートアップコネクト</a
+              >
+            </div>
+            <nav class="hidden md:ml-6 md:flex space-x-4">
+              <a
+                href="dashboard.html"
+                class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                >ホーム</a
+              >
+              <a
+                href="search.html"
+                class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                >検索</a
+              >
+              <a
+                href="messages.html"
+                class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                >メッセージ</a
+              >
+              <a
+                href="groups.html"
+                class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                >グループ</a
+              >
+              <a
+                href="events.html"
+                class="bg-blue-50 text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                >イベント</a
+              >
+            </nav>
+          </div>
+          <div class="hidden md:flex items-center">
+            <button
+              type="button"
+              id="notification-button"
+              onclick="location.href='notifications.html';"
+              class="relative p-1 rounded-full text-gray-500 hover:text-blue-600 focus:outline-none"
+            >
+              <span class="sr-only">通知を見る</span>
+              <svg
+                class="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                ></path>
+              </svg>
+              <span
+                id="notification-dot"
+                class="hidden absolute top-0 right-0 block h-2 w-2 rounded-full bg-red-500"
+              ></span>
+            </button>
+
+            <div class="ml-3 relative">
+              <div class="flex items-center">
+                <button
+                  type="button"
+                  class="bg-gray-800 flex text-sm rounded-full focus:outline-none"
+                  id="user-menu-button"
+                >
+                  <span class="sr-only">メニューを開く</span>
+                  <img
+                    id="user-avatar"
+                    class="h-8 w-8 rounded-full object-cover"
+                    src="/api/placeholder/32/32"
+                    alt="プロフィール"
+                  />
+                </button>
+                <div class="ml-2 hidden md:block">
+                  <div id="user-name" class="text-sm font-medium text-gray-800">
+                    -
+                  </div>
+                  <div id="user-location" class="text-xs text-gray-500">-</div>
+                </div>
+              </div>
+
+              <div
+                id="user-menu"
+                class="hidden origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-30"
+              >
+                <a
+                  href="profile.html"
+                  class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                  >プロフィール</a
+                >
+                <a
+                  href="settings.html"
+                  class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                  >設定</a
+                >
+                <a
+                  href="#"
+                  id="logout-link"
+                  class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                  >ログアウト</a
+                >
+              </div>
+            </div>
+          </div>
+
+          <div class="flex md:hidden items-center">
+            <button
+              type="button"
+              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+            >
+              <svg
+                class="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 6h16M4 12h16M4 18h16"
+                ></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- モバイルメニュー -->
+      <div class="mobile-menu hidden md:hidden bg-white border-t">
+        <a
+          href="dashboard.html"
+          class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          >ホーム</a
+        >
+        <a
+          href="search.html"
+          class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          >検索</a
+        >
+        <a
+          href="messages.html"
+          class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          >メッセージ</a
+        >
+        <a
+          href="groups.html"
+          class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          >グループ</a
+        >
+        <a href="events.html" class="block px-4 py-2 bg-blue-50 text-blue-600"
+          >イベント</a
+        >
+        <div class="border-t border-gray-200 my-1"></div>
+        <a
+          href="profile.html"
+          class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          >プロフィール</a
+        >
+        <a
+          href="settings.html"
+          class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          >設定</a
+        >
+        <a
+          href="#"
+          class="logout-link-mobile block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          >ログアウト</a
+        >
+      </div>
+    </header>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-3xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      <div id="loading" class="text-center text-gray-500">読み込み中...</div>
+      <div id="event-content" class="hidden"></div>
+    </main>
+
+    <script>
+      const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
+      const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+      let currentUser = null;
+      let userProfile = null;
+      let eventData = null;
+      let participants = [];
+
+      window.addEventListener('load', async () => {
+        await checkAuth();
+        const eventId = getUrlParam('event');
+        if (!eventId) {
+          showError('イベントIDが指定されていません');
+          return;
+        }
+        await loadEvent(eventId);
+      });
+
+      async function checkAuth() {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+          window.location.href = 'login.html';
+          return;
+        }
+        currentUser = user;
+        await loadCurrentUserProfile();
+      }
+
+      async function loadCurrentUserProfile() {
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('*')
+          .eq('id', currentUser.id)
+          .single();
+        if (profile) {
+          userProfile = profile;
+          updateUserInfo(profile);
+        }
+      }
+
+      function updateUserInfo(profile) {
+        document.getElementById('user-name').textContent = `${profile.last_name} ${profile.first_name}`;
+        document.getElementById('user-location').textContent = profile.location;
+        if (profile.profile_image_url) {
+          document.getElementById('user-avatar').src = profile.profile_image_url;
+        }
+      }
+
+      function getUrlParam(name) {
+        const params = new URLSearchParams(window.location.search);
+        return params.get(name);
+      }
+
+      async function loadEvent(eventId) {
+        const { data: event, error } = await supabase
+          .from('events')
+          .select(`*, organizer:profiles!events_organizer_id_fkey(*)`)
+          .eq('id', eventId)
+          .single();
+        if (error || !event) {
+          showError('イベントが見つかりません');
+          return;
+        }
+        eventData = event;
+
+        const { data: memberRows } = await supabase
+          .from('event_participants')
+          .select(`user_id, profiles!inner(*)`)
+          .eq('event_id', eventId);
+        participants = memberRows ? memberRows.map((m) => m.profiles) : [];
+
+        displayEvent();
+      }
+
+      function displayEvent() {
+        const container = document.getElementById('event-content');
+        document.getElementById('loading').classList.add('hidden');
+        container.classList.remove('hidden');
+
+        const isParticipating = participants.some((p) => p.id === currentUser.id);
+        const remainingSeats = eventData.max_attendees
+          ? eventData.max_attendees - participants.length
+          : null;
+        const isFull = remainingSeats !== null && remainingSeats <= 0;
+
+        const participantAvatars = participants
+          .map((p) => `<img class="h-8 w-8 rounded-full object-cover" src="${p.profile_image_url || '/api/placeholder/32/32'}" alt="${p.last_name}" />`)
+          .join('');
+
+        const locationText = eventData.format === 'online'
+          ? 'オンライン'
+          : eventData.location;
+
+        container.innerHTML = `
+          <h1 class="text-2xl font-bold mb-4">${eventData.title}</h1>
+          <img src="${eventData.image_url || '/api/placeholder/600/300'}" alt="${eventData.title}" class="w-full h-60 object-cover rounded mb-4">
+          <p class="text-sm text-gray-600 mb-1">主催: ${eventData.organizer?.last_name || ''} ${eventData.organizer?.first_name || ''}</p>
+          <p class="text-sm text-gray-600 mb-1">日時: ${new Date(eventData.event_date).toLocaleDateString()} ${eventData.start_time} - ${eventData.end_time}</p>
+          <p class="text-sm text-gray-600 mb-4">場所: ${locationText}</p>
+          <p class="mb-6 whitespace-pre-wrap">${eventData.description}</p>
+          <div class="mb-6">
+            <h2 class="font-semibold mb-2">参加者 (${participants.length})</h2>
+            <div class="flex -space-x-2">${participantAvatars}</div>
+          </div>
+          <div id="action-area"></div>
+        `;
+
+        const actionArea = document.getElementById('action-area');
+        if (eventData.organizer_id !== currentUser.id) {
+          if (isParticipating) {
+            actionArea.innerHTML = `<button id="leave-btn" class="px-4 py-2 border border-red-600 text-red-600 rounded-lg">参加取消</button>`;
+            document.getElementById('leave-btn').addEventListener('click', () => leaveEvent(eventData.id));
+          } else {
+            const disabledAttr = isFull ? 'disabled' : '';
+            const label = isFull ? '満席' : '参加する';
+            actionArea.innerHTML = `<button id="join-btn" class="px-4 py-2 bg-blue-600 text-white rounded-lg ${isFull ? 'opacity-50 cursor-not-allowed' : ''}" ${disabledAttr}>${label}</button>`;
+            if (!isFull) {
+              document.getElementById('join-btn').addEventListener('click', () => joinEvent(eventData.id));
+            }
+          }
+        }
+      }
+
+      async function joinEvent(eventId) {
+        const { error } = await supabase.from('event_participants').insert({
+          event_id: eventId,
+          user_id: currentUser.id,
+        });
+        if (error) {
+          alert('参加に失敗しました');
+          return;
+        }
+        participants.push(userProfile);
+        displayEvent();
+
+        if (eventData.organizer_id !== currentUser.id) {
+          await supabase.from('notifications').insert({
+            user_id: eventData.organizer_id,
+            type: 'event_join',
+            title: 'イベント参加',
+            content: `${userProfile.last_name} ${userProfile.first_name}さんがあなたのイベント「${eventData.title}」に参加しました`,
+            related_id: eventId,
+          });
+        }
+      }
+
+      async function leaveEvent(eventId) {
+        const { error } = await supabase
+          .from('event_participants')
+          .delete()
+          .eq('event_id', eventId)
+          .eq('user_id', currentUser.id);
+        if (error) {
+          alert('参加取消に失敗しました');
+          return;
+        }
+        participants = participants.filter((p) => p.id !== currentUser.id);
+        displayEvent();
+      }
+
+      function showError(message) {
+        const loading = document.getElementById('loading');
+        loading.textContent = message;
+      }
+
+      document.querySelector('.mobile-menu-button').addEventListener('click', () => {
+        document.querySelector('.mobile-menu').classList.toggle('hidden');
+      });
+      document.getElementById('user-menu-button').addEventListener('click', () => {
+        document.getElementById('user-menu').classList.toggle('hidden');
+      });
+      document.getElementById('logout-link').addEventListener('click', async (e) => {
+        e.preventDefault();
+        await supabase.auth.signOut();
+        window.location.href = 'login.html?message=logout';
+      });
+      document.querySelector('.logout-link-mobile').addEventListener('click', async (e) => {
+        e.preventDefault();
+        await supabase.auth.signOut();
+        window.location.href = 'login.html?message=logout';
+      });
+    </script>
+  </body>
+</html>

--- a/events.html
+++ b/events.html
@@ -1223,8 +1223,7 @@
 
       // イベント詳細表示
       function viewEventDetails(eventId) {
-        // イベント詳細ページへの遷移（実装時）
-        console.log("View event details:", eventId);
+        window.location.href = `event-detail.html?event=${eventId}`;
       }
 
       // イベント作成


### PR DESCRIPTION
## Summary
- add new **event-detail.html** page
- redirect `viewEventDetails` in `events.html` to the new page
- show event information, participants, and join/leave controls on detail page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68503cd019508330b130c354ec7ba499