### PR TITLE
Implement user session tracking and management

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -564,6 +564,32 @@
       let currentUser = null;
       let userProfile = null;
 
+      async function recordSession(user) {
+        try {
+          const { data: sessionData } = await supabase.auth.getSession();
+          if (!sessionData.session) return;
+          const ipRes = await fetch("https://api.ipify.org?format=json");
+          const ipData = await ipRes.json();
+          await fetch("/api/user_sessions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              user_id: user.id,
+              session_token: sessionData.session.access_token,
+              ip_address: ipData.ip,
+              device_info: navigator.platform,
+              user_agent: navigator.userAgent,
+              last_activity: new Date().toISOString(),
+              expires_at: new Date(
+                sessionData.session.expires_at * 1000
+              ).toISOString(),
+            }),
+          });
+        } catch (e) {
+          console.error("session record failed", e);
+        }
+      }
+
       // 地域名マッピング
       const locationNames = {
         hokkaido: "北海道",
@@ -653,6 +679,7 @@
           return;
         }
         currentUser = user;
+        await recordSession(user);
         await loadUserProfile();
       }
 

--- a/login.html
+++ b/login.html
@@ -421,6 +421,27 @@
             } else {
               showSuccess("ログインに成功しました。リダイレクトしています...");
 
+              // セッション情報保存
+              try {
+                const ipRes = await fetch("https://api.ipify.org?format=json");
+                const ipData = await ipRes.json();
+                await fetch("/api/user_sessions", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    user_id: data.user.id,
+                    session_token: data.session.access_token,
+                    ip_address: ipData.ip,
+                    device_info: navigator.platform,
+                    user_agent: navigator.userAgent,
+                    last_activity: new Date().toISOString(),
+                    expires_at: new Date(data.session.expires_at * 1000).toISOString(),
+                  }),
+                });
+              } catch (e) {
+                console.error("session record failed", e);
+              }
+
               // プロフィール情報を確認
               const { data: profile, error: profileError } = await supabase
                 .from("profiles")

--- a/settings.html
+++ b/settings.html
@@ -1361,26 +1361,66 @@
 
       // アクティブセッション読み込み
       async function loadActiveSessions() {
-        // 簡単なセッション情報の表示（実際のアプリでは更に詳細な実装が必要）
         const container = document.getElementById("active-sessions");
-        container.innerHTML = `
-                <div class="py-4 flex justify-between">
-                    <div class="flex items-center">
-                        <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                        <div class="ml-3">
-                            <div class="text-sm font-medium text-gray-900">現在のブラウザセッション</div>
-                            <div class="text-xs text-gray-500">現在アクティブ</div>
-                        </div>
-                    </div>
-                    <div class="flex items-center">
-                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                            現在のセッション
-                        </span>
-                    </div>
-                </div>
-            `;
+        container.innerHTML = "";
+        const { data: sessionData } = await supabase.auth.getSession();
+        const currentToken = sessionData.session?.access_token || "";
+        const { data: sessions } = await supabase
+          .from("user_sessions")
+          .select("*")
+          .eq("user_id", currentUser.id)
+          .order("last_activity", { ascending: false });
+
+        sessions.forEach((s) => {
+          const div = document.createElement("div");
+          div.className = "py-4 flex justify-between";
+          div.innerHTML = `
+            <div class="flex items-center">
+              <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+              <div class="ml-3">
+                <div class="text-sm font-medium text-gray-900">${s.device_info}</div>
+                <div class="text-xs text-gray-500">${s.ip_address}</div>
+              </div>
+            </div>
+            <div class="flex items-center space-x-2">
+              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                s.session_token === currentToken ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-800"
+              }">${s.session_token === currentToken ? "現在のセッション" : ""}</span>
+              <button data-token="${s.session_token}" class="text-sm text-red-600 hover:text-red-900">終了</button>
+            </div>`;
+          container.appendChild(div);
+        });
+
+        container.querySelectorAll("button[data-token]").forEach((btn) => {
+          btn.addEventListener("click", () => revokeSession(btn.dataset.token));
+        });
+      }
+
+      async function revokeSession(token) {
+        const confirmed = await showConfirm(
+          "セッション終了",
+          "このセッションを終了しますか？"
+        );
+        if (!confirmed) return;
+        showLoading();
+        try {
+          await fetch("/api/revoke_session", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ session_token: token }),
+          });
+          await loadActiveSessions();
+          const { data: sessionData } = await supabase.auth.getSession();
+          if (sessionData.session && sessionData.session.access_token === token) {
+            window.location.href = "login.html?message=logout";
+          }
+        } catch (error) {
+          showError("セッションの操作に失敗しました: " + error.message);
+        } finally {
+          hideLoading();
+        }
       }
 
       // イベントリスナー設定
@@ -2007,10 +2047,17 @@
 
         showLoading();
         try {
-          // Supabaseの場合、現在のセッション以外を終了する機能は限定的
-          // 実際のアプリでは、カスタムのセッション管理が必要
-          await supabase.auth.refreshSession();
-          showSuccess("セッションを更新しました。");
+          const { data: sessionData } = await supabase.auth.getSession();
+          if (!sessionData.session) throw new Error("no session");
+          await fetch("/api/revoke_all_sessions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              user_id: currentUser.id,
+              current_token: sessionData.session.access_token,
+            }),
+          });
+          window.location.href = "login.html?message=logout";
         } catch (error) {
           showError("セッションの操作に失敗しました: " + error.message);
         } finally {
@@ -2049,6 +2096,14 @@
       // ログアウト
       async function logout(e) {
         e.preventDefault();
+        const { data: sessionData } = await supabase.auth.getSession();
+        if (sessionData.session) {
+          await fetch("/api/revoke_session", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ session_token: sessionData.session.access_token }),
+          });
+        }
         await supabase.auth.signOut();
         window.location.href = "login.html?message=logout";
       }


### PR DESCRIPTION
## Summary
- capture IP and device info after user login
- store session details with `/api/user_sessions`
- show active sessions in settings and allow revoking them
- handle logout and session revocation on the server

## Testing
- `npm install --silent`
- `node server.js` *(fails: The requested module 'openai' does not provide an export named 'Configuration')*

------
https://chatgpt.com/codex/tasks/task_e_68503cd3c23c8330a819b003c4fe40c5