### PR TITLE
Add setup instructions and config checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,30 @@ Summary：
 Startup Connect helps aspiring founders meet co-founders, mentors, and investors.
 It offers advanced search, real-time chat, community groups, event management, and
 AI-powered matching to streamline building a startup team.
+
+## Setup
+
+1. Create a `.env` file with your Supabase credentials:
+
+   ```env
+   SUPABASE_URL=<your-supabase-url>
+   SUPABASE_ANON_KEY=<your-anon-key>
+   PUSH_VAPID_PUBLIC_KEY=<your-vapid-key>
+   ```
+
+2. Generate `config.js` from the template:
+
+   ```bash
+   npm run build
+   ```
+
+3. Install dependencies and start the server:
+
+   ```bash
+   npm install
+   npm start
+   ```
+
+If `config.js` is not generated correctly, the login and registration pages will
+fail to connect to Supabase. Ensure the environment variables are set and the
+build step has been executed.

--- a/login.html
+++ b/login.html
@@ -381,6 +381,14 @@
         SUPABASE_URL,
         SUPABASE_ANON_KEY
       );
+      if (
+        SUPABASE_URL === 'https://example.supabase.co' ||
+        SUPABASE_ANON_KEY === 'anon'
+      ) {
+        alert(
+          'config.js is not configured. Set environment variables and run `npm run build`.'
+        );
+      }
       // モバイルメニューの表示/非表示
       document
         .querySelector(".mobile-menu-button")

--- a/register.html
+++ b/register.html
@@ -996,6 +996,14 @@
         SUPABASE_URL,
         SUPABASE_ANON_KEY
       );
+      if (
+        SUPABASE_URL === 'https://example.supabase.co' ||
+        SUPABASE_ANON_KEY === 'anon'
+      ) {
+        alert(
+          'config.js is not configured. Set environment variables and run `npm run build`.'
+        );
+      }
 
       // グローバル変数
       let currentStep = 1;


### PR DESCRIPTION
## Summary
- document how to provide Supabase credentials and build config.js
- warn on login and register pages when config.js still uses placeholders

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68504a232c0c8330add5eb2898a8372f