### PR TITLE
Enhance password inputs

### DIFF
--- a/login.html
+++ b/login.html
@@ -173,15 +173,26 @@
             </div>
             <div>
               <label for="password" class="sr-only">パスワード</label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autocomplete="current-password"
-                required
-                class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                placeholder="パスワード"
-              />
+              <div class="relative">
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autocomplete="current-password"
+                  required
+                  class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm pr-10"
+                  placeholder="パスワード"
+                />
+                <button
+                  type="button"
+                  id="toggle-login-password"
+                  class="absolute inset-y-0 right-0 px-3 text-gray-500"
+                  aria-label="パスワードを表示"
+                >
+                  表示
+                </button>
+              </div>
+              <div id="login-password-strength" class="mt-1 text-xs text-gray-500"></div>
             </div>
           </div>
 
@@ -500,6 +511,42 @@
           cancel.addEventListener("click", handleCancel);
         });
       }
+
+      function evaluatePasswordStrength(pw) {
+        let score = 0;
+        if (pw.length >= 8) score++;
+        if (/[A-Z]/.test(pw)) score++;
+        if (/[0-9]/.test(pw)) score++;
+        if (/[^A-Za-z0-9]/.test(pw)) score++;
+        if (score <= 1) return { text: "弱い", color: "text-red-500" };
+        if (score <= 3) return { text: "普通", color: "text-yellow-500" };
+        return { text: "強い", color: "text-green-500" };
+      }
+
+      function toggleVisibility(id, btn) {
+        const input = document.getElementById(id);
+        if (input.type === "password") {
+          input.type = "text";
+          btn.textContent = "隠す";
+        } else {
+          input.type = "password";
+          btn.textContent = "表示";
+        }
+      }
+
+      document
+        .getElementById("password")
+        .addEventListener("input", (e) => {
+          const { text, color } = evaluatePasswordStrength(e.target.value);
+          const el = document.getElementById("login-password-strength");
+          el.textContent = `強度: ${text}`;
+          el.className = `mt-1 text-xs ${color}`;
+        });
+      document
+        .getElementById("toggle-login-password")
+        .addEventListener("click", function () {
+          toggleVisibility("password", this);
+        });
       // ログインフォームの処理
       document
         .getElementById("login-form")

--- a/register.html
+++ b/register.html
@@ -272,15 +272,26 @@
                   class="block text-sm font-medium text-gray-700 mb-1"
                   >パスワード <span class="text-red-600">*</span></label
                 >
-                <input
-                  type="password"
-                  id="password"
-                  name="password"
-                  class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="8文字以上の英数字"
-                  minlength="8"
-                  required
-                />
+                <div class="relative">
+                  <input
+                    type="password"
+                    id="password"
+                    name="password"
+                    class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 pr-10"
+                    placeholder="8文字以上の英数字"
+                    minlength="8"
+                    required
+                  />
+                  <button
+                    type="button"
+                    id="toggle-password"
+                    class="absolute inset-y-0 right-0 px-3 text-gray-500"
+                    aria-label="パスワードを表示"
+                  >
+                    表示
+                  </button>
+                </div>
+                <div id="password-strength" class="mt-1 text-xs text-gray-500"></div>
                 <p class="mt-1 text-xs text-gray-500">
                   ※8文字以上で、英字・数字を含めてください
                 </p>
@@ -292,15 +303,25 @@
                   class="block text-sm font-medium text-gray-700 mb-1"
                   >パスワード（確認） <span class="text-red-600">*</span></label
                 >
-                <input
-                  type="password"
-                  id="password_confirm"
-                  name="password_confirm"
-                  class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="8文字以上の英数字"
-                  minlength="8"
-                  required
-                />
+                <div class="relative">
+                  <input
+                    type="password"
+                    id="password_confirm"
+                    name="password_confirm"
+                    class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 pr-10"
+                    placeholder="8文字以上の英数字"
+                    minlength="8"
+                    required
+                  />
+                  <button
+                    type="button"
+                    id="toggle-password-confirm"
+                    class="absolute inset-y-0 right-0 px-3 text-gray-500"
+                    aria-label="パスワードを表示"
+                  >
+                    表示
+                  </button>
+                </div>
               </div>
 
               <div class="mb-6">
@@ -1201,6 +1222,47 @@
 
         return isValid;
       }
+
+      function evaluatePasswordStrength(pw) {
+        let score = 0;
+        if (pw.length >= 8) score++;
+        if (/[A-Z]/.test(pw)) score++;
+        if (/[0-9]/.test(pw)) score++;
+        if (/[^A-Za-z0-9]/.test(pw)) score++;
+        if (score <= 1) return { text: "弱い", color: "text-red-500" };
+        if (score <= 3) return { text: "普通", color: "text-yellow-500" };
+        return { text: "強い", color: "text-green-500" };
+      }
+
+      function toggleVisibility(id, btn) {
+        const input = document.getElementById(id);
+        if (input.type === "password") {
+          input.type = "text";
+          btn.textContent = "隠す";
+        } else {
+          input.type = "password";
+          btn.textContent = "表示";
+        }
+      }
+
+      document
+        .getElementById("password")
+        .addEventListener("input", (e) => {
+          const { text, color } = evaluatePasswordStrength(e.target.value);
+          const el = document.getElementById("password-strength");
+          el.textContent = `強度: ${text}`;
+          el.className = `mt-1 text-xs ${color}`;
+        });
+      document
+        .getElementById("toggle-password")
+        .addEventListener("click", function () {
+          toggleVisibility("password", this);
+        });
+      document
+        .getElementById("toggle-password-confirm")
+        .addEventListener("click", function () {
+          toggleVisibility("password_confirm", this);
+        });
 
       // アカウント作成
       async function createAccount() {


### PR DESCRIPTION
## Summary
- show/hide password controls on register and login pages
- display password strength feedback while typing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68506a30a0588330a521a298e684160c