### PR TITLE
Add email verification step

### DIFF
--- a/login.html
+++ b/login.html
@@ -527,6 +527,9 @@
               } else {
                 showError("ログインに失敗しました。もう一度お試しください。");
               }
+            } else if (!data.user.email_confirmed_at) {
+              showError("メールアドレスの確認が完了していません。メールをご確認ください。");
+              await supabase.auth.signOut();
             } else {
               const { data: settings } = await supabase
                 .from("security_settings")

--- a/register.html
+++ b/register.html
@@ -163,7 +163,7 @@
           </div>
 
           <!-- 進捗バー -->
-          <div class="max-w-3xl mx-auto mb-10">
+          <div id="progress-container" class="max-w-3xl mx-auto mb-10">
             <div class="flex items-center justify-between mb-2">
               <div class="flex flex-col items-center">
                 <div
@@ -959,6 +959,11 @@
               </div>
             </section>
           </form>
+          <div id="check-email-message" class="hidden p-6 text-center border border-green-300 bg-green-50 rounded-md mt-6">
+            <p class="text-lg text-gray-800 mb-4">確認メールを送信しました。</p>
+            <p class="text-gray-700">メールに記載されたリンクをクリックして登録を完了してください。</p>
+            <p class="text-gray-700 mt-2">確認後、ログインページからサインインしてください。</p>
+          </div>
         </div>
 
         <div class="px-6 py-4 bg-gray-50 border-t border-gray-200">
@@ -1215,6 +1220,7 @@
             email: email,
             password: password,
             options: {
+              emailRedirectTo: window.location.origin + "/login.html",
               data: {
                 first_name: firstName,
                 last_name: lastName,
@@ -1231,7 +1237,15 @@
             }
           } else {
             userId = data.user.id;
-            moveToStep(2);
+            document
+              .getElementById("registration-form")
+              .classList.add("hidden");
+            document
+              .getElementById("progress-container")
+              .classList.add("hidden");
+            document
+              .getElementById("check-email-message")
+              .classList.remove("hidden");
           }
         } catch (error) {
           console.error("Unexpected error:", error);


### PR DESCRIPTION
## Summary
- prompt users to check their inbox after signup
- send an email confirmation link when signing up
- block logins until email is verified

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68506a3674008330a8692ab5a068b1d0