### PR TITLE
Handle missing profiles before startup updates

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -1212,6 +1212,25 @@
               skills: skills,
             };
 
+            const { data: existingProfile } = await supabase
+              .from("profiles")
+              .select("id")
+              .eq("id", currentUser.id)
+              .single();
+
+            if (!existingProfile) {
+              const { error: insertError } = await supabase.from("profiles").insert({
+                id: currentUser.id,
+                first_name: document.getElementById("first_name").value,
+                last_name: document.getElementById("last_name").value,
+                location: document.getElementById("location").value,
+                age_range: document.getElementById("age_range").value,
+              });
+              if (insertError) {
+                throw new Error("プロフィール情報の保存に失敗しました");
+              }
+            }
+
             const { error: profileError } = await supabase
               .from("profiles")
               .update(profileData)

--- a/register.html
+++ b/register.html
@@ -1761,6 +1761,27 @@
             ).map((cb) => cb.value);
 
             // プロフィール情報の更新
+            const { data: existingProfile } = await supabase
+              .from("profiles")
+              .select("id")
+              .eq("id", user.id)
+              .single();
+
+            if (!existingProfile) {
+              const { error: insertError } = await supabase.from("profiles").insert({
+                id: user.id,
+                first_name: document.getElementById("first_name").value,
+                last_name: document.getElementById("last_name").value,
+                location: document.getElementById("location").value,
+                age_range: document.getElementById("age").value,
+              });
+              if (insertError) {
+                console.error("Profile insert error:", insertError);
+                showError("プロフィール情報の保存に失敗しました。");
+                return;
+              }
+            }
+
             const { error: profileError } = await supabase
               .from("profiles")
               .update({


### PR DESCRIPTION
## Summary
- check for an existing profile before saving registration details
- do the same when editing the profile page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850740ac7dc833090dac9b328f14cc7