### PR TITLE
Add email verification landing page

### DIFF
--- a/register.html
+++ b/register.html
@@ -1560,7 +1560,8 @@
             email: email,
             password: password,
             options: {
-              emailRedirectTo: window.location.origin + "/login.html",
+              emailRedirectTo: window.location.origin + "/verify.html",
+              redirectTo: window.location.origin + "/verify.html",
               data: {
                 first_name: firstName,
                 last_name: lastName,

--- a/verify.html
+++ b/verify.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
+    <title>メール確認 - スタートアップコネクト</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="config.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <style>
+      body {
+        font-family: "Noto Sans JP", sans-serif;
+      }
+    </style>
+  </head>
+  <body class="bg-gray-50 flex items-center justify-center min-h-screen">
+    <div id="message" class="p-6 text-center border border-green-300 bg-green-50 rounded-md">
+      <p>メール確認中...</p>
+    </div>
+    <script>
+      const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
+      const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+      async function completeVerification(user) {
+        const { data: profile, error } = await supabase
+          .from("profiles")
+          .select("id")
+          .eq("id", user.id)
+          .single();
+
+        if (error) {
+          await supabase.from("profiles").insert({
+            id: user.id,
+            first_name: user.user_metadata.first_name || "",
+            last_name: user.user_metadata.last_name || "",
+            location: "",
+            age_range: "",
+          });
+        }
+        document.getElementById("message").innerHTML = "メール確認が完了しました。登録を続行します...";
+        setTimeout(() => {
+          window.location.href = "register.html?step=2";
+        }, 2000);
+      }
+
+      supabase.auth.onAuthStateChange(async (event, session) => {
+        if (event === "SIGNED_IN" && session) {
+          completeVerification(session.user);
+        }
+      });
+
+      (async () => {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) {
+          await completeVerification(user);
+        }
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- after sign up redirect to new verify.html
- create verify.html to handle email confirmation
- automatically create profile if missing and continue registration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685074169e8c8330978296140154054d