### PR TITLE
Add profile creation logic tests

### DIFF
--- a/__tests__/profile.test.js
+++ b/__tests__/profile.test.js
@@ -1,0 +1,23 @@
+import { jest } from '@jest/globals';
+import { loginAndEnsureProfile } from '../js/auth.js';
+
+test('login inserts profile row when missing', async () => {
+  const insert = jest.fn().mockResolvedValue({ error: null });
+  const profileApi = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+    insert,
+  };
+  const supabase = {
+    auth: {
+      signInWithPassword: jest.fn().mockResolvedValue({ data: { user: { id: 1 } } }),
+    },
+    from: jest.fn(() => profileApi),
+  };
+
+  const result = await loginAndEnsureProfile(supabase, 'a@example.com', 'pw');
+
+  expect(result).toEqual({ user: { id: 1 }, profile: { id: 1 } });
+  expect(insert).toHaveBeenCalledWith({ id: 1 });
+});

--- a/js/auth.js
+++ b/js/auth.js
@@ -2,3 +2,33 @@ export async function checkAuth(supabase) {
   const { data: { user } } = await supabase.auth.getUser();
   return user || null;
 }
+
+// Log in and ensure a profile row exists for the user
+export async function loginAndEnsureProfile(supabase, email, password) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+  if (error || !data?.user) {
+    throw new Error('login failed');
+  }
+  const user = data.user;
+
+  let { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', user.id)
+    .single();
+
+  if (profileError || !profile) {
+    const { error: insertError } = await supabase
+      .from('profiles')
+      .insert({ id: user.id });
+    if (insertError) {
+      throw new Error('failed to create profile');
+    }
+    profile = { id: user.id };
+  }
+
+  return { user, profile };
+}


### PR DESCRIPTION
## Summary
- add `loginAndEnsureProfile` function in `js/auth.js` to insert a profile row on login when missing
- create `profile.test.js` with mocked Supabase client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850742f675c8330aaa9862c80b8a73d