### PR TITLE
Add caching service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -882,5 +882,14 @@
     </script>
     <script src="i18n.js"></script>
     <script src="accessibility.js"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          if (!navigator.serviceWorker.controller) {
+            navigator.serviceWorker.register('sw.js').catch(console.error);
+          }
+        });
+      }
+    </script>
   </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,59 @@
+const CACHE_NAME = 'startup-connect-cache-v1';
+const ASSETS = [
+  '/styles/styles.css',
+  '/index.html',
+  '/login.html',
+  '/register.html',
+  '/reset-password.html',
+  '/verify.html',
+  '/dashboard.html',
+  '/events.html',
+  '/event-detail.html',
+  '/search.html',
+  '/messages.html',
+  '/groups.html',
+  '/profile.html',
+  '/profile-detail.html',
+  '/projects.html',
+  '/connections.html',
+  '/notifications.html',
+  '/settings.html'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  if (!['document', 'style', 'image'].includes(event.request.destination)) return;
+
+  event.respondWith(
+    caches.match(event.request).then(resp => {
+      if (resp) return resp;
+      return fetch(event.request)
+        .then(networkResp => {
+          if (networkResp && networkResp.status === 200) {
+            const clone = networkResp.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          }
+          return networkResp;
+        })
+        .catch(() => caches.match('/index.html'));
+    })
+  );
+});
+
 self.addEventListener('push', event => {
   let data = {};
   if (event.data) {


### PR DESCRIPTION
## Summary
- implement service worker install, activate and fetch events
- cache HTML, CSS and images
- register service worker on the landing page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68508399338c8330902c354f149e670d