### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/connections.html
+++ b/connections.html
@@ -75,7 +75,7 @@
               </svg>
               <span class="absolute top-0 right-0 block h-2 w-2 rounded-full bg-red-500"></span>
             </a>
-            <button type="button" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none">
+            <button type="button" aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none">
               <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" ></path>
               </svg>
@@ -84,7 +84,7 @@
         </div>
       </div>
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a href="dashboard.html" class="block px-4 py-2 text-gray-500 hover:bg-gray-100">ホーム</a>
         <a href="search.html" class="block px-4 py-2 text-gray-500 hover:bg-gray-100">検索</a>
         <a href="messages.html" class="block px-4 py-2 text-gray-500 hover:bg-gray-100">メッセージ</a>
@@ -287,6 +287,11 @@
         e.preventDefault();
         await supabase.auth.signOut();
         window.location.href = 'login.html?message=logout';
+      });
+      document.querySelector('.mobile-menu-button').addEventListener('click', function () {
+        const menu = document.getElementById('mobile-menu');
+        const expanded = menu.classList.toggle('hidden') ? false : true;
+        this.setAttribute('aria-expanded', expanded);
       });
       document.getElementById('user-menu-button').addEventListener('click', function () {
         document.getElementById('user-menu').classList.toggle('hidden');

--- a/dashboard.html
+++ b/dashboard.html
@@ -220,7 +220,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -241,7 +241,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
         <a
           href="dashboard.html"
           class="block px-4 py-2 bg-blue-50 text-blue-600"
@@ -1340,7 +1340,7 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          const menu = document.querySelector(".mobile-menu");
+          const menu = document.getElementById("mobile-menu");
           const expanded = menu.classList.toggle("hidden") ? false : true;
           this.setAttribute("aria-expanded", expanded);
         });

--- a/event-detail.html
+++ b/event-detail.html
@@ -181,7 +181,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -202,7 +202,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -417,8 +417,10 @@
         loading.textContent = message;
       }
 
-      document.querySelector('.mobile-menu-button').addEventListener('click', () => {
-        document.querySelector('.mobile-menu').classList.toggle('hidden');
+      document.querySelector('.mobile-menu-button').addEventListener('click', function () {
+        const menu = document.getElementById('mobile-menu');
+        const expanded = menu.classList.toggle('hidden') ? false : true;
+        this.setAttribute('aria-expanded', expanded);
       });
       document.getElementById('user-menu-button').addEventListener('click', () => {
         document.getElementById('user-menu').classList.toggle('hidden');

--- a/events.html
+++ b/events.html
@@ -181,7 +181,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -202,7 +202,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1502,7 +1502,9 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
         });
 
       document

--- a/groups.html
+++ b/groups.html
@@ -197,7 +197,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -218,7 +218,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1911,7 +1911,7 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          const menu = document.querySelector(".mobile-menu");
+          const menu = document.getElementById("mobile-menu");
           const expanded = menu.classList.toggle("hidden") ? false : true;
           this.setAttribute("aria-expanded", expanded);
         });

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -107,7 +107,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
         <a
           href="#features"
           class="block px-4 py-2 text-gray-600 hover:bg-gray-100"
@@ -852,7 +852,9 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
         });
 
       // スムーススクロール

--- a/login.html
+++ b/login.html
@@ -74,7 +74,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -95,7 +95,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="index.html#features"
           class="block px-4 py-2 text-gray-600 hover:bg-gray-100"
@@ -404,7 +404,9 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
         });
 
       // エラーメッセージを表示

--- a/messages.html
+++ b/messages.html
@@ -187,7 +187,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -208,7 +208,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1686,7 +1686,9 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
         });
 
       document

--- a/notifications.html
+++ b/notifications.html
@@ -209,7 +209,7 @@
 
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -230,7 +230,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1201,7 +1201,9 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
         });
 
       document

--- a/profile-detail.html
+++ b/profile-detail.html
@@ -198,7 +198,7 @@
 
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -219,7 +219,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1540,7 +1540,9 @@
         document
           .querySelector(".mobile-menu-button")
           .addEventListener("click", function () {
-            document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
           });
 
         // ユーザーメニュー

--- a/profile.html
+++ b/profile.html
@@ -168,7 +168,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -189,7 +189,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1422,7 +1422,9 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
         });
 
       document

--- a/register.html
+++ b/register.html
@@ -95,7 +95,7 @@
           <div class="flex md:hidden items-center">
             <button aria-label="メニューを開く"
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -116,7 +116,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="index.html#features"
           class="block px-4 py-2 text-gray-600 hover:bg-gray-100"
@@ -1180,7 +1180,9 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
         });
 
       // エラーメッセージを表示

--- a/search.html
+++ b/search.html
@@ -191,7 +191,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -212,7 +212,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1642,7 +1642,7 @@
       document
         .querySelector(".mobile-menu-button")
         .addEventListener("click", function () {
-          const menu = document.querySelector(".mobile-menu");
+          const menu = document.getElementById("mobile-menu");
           const expanded = menu.classList.toggle("hidden") ? false : true;
           this.setAttribute("aria-expanded", expanded);
         });

--- a/settings.html
+++ b/settings.html
@@ -189,7 +189,7 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
-              class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
+              aria-expanded="false" aria-controls="mobile-menu" class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
                 class="h-6 w-6"
@@ -210,7 +210,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t">
         <a
           href="dashboard.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
@@ -1448,7 +1448,9 @@
         document
           .querySelector(".mobile-menu-button")
           .addEventListener("click", () => {
-            document.querySelector(".mobile-menu").classList.toggle("hidden");
+          const menu = document.getElementById("mobile-menu");
+          const expanded = menu.classList.toggle("hidden") ? false : true;
+          this.setAttribute("aria-expanded", expanded);
           });
 
         // ウィンドウクリックでメニューを閉じる


### PR DESCRIPTION
## Summary
- add `aria-expanded` and `aria-controls` attributes for every `.mobile-menu-button`
- provide `id="mobile-menu"` on the collapsible menu container
- toggle the button's `aria-expanded` state when opening/closing the mobile menu

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68508396903c83308076f68a7a9fced9