### PR TITLE
Fix timezone-sensitive event date parsing

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -19,7 +19,8 @@ export function filterEvents(allEvents, { type = '', location = '', date = '' } 
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
     filtered = filtered.filter(event => {
-      const eventDate = new Date(event.event_date);
+      // Parse the event date as a local date to avoid timezone issues
+      const eventDate = new Date(`${event.event_date}T00:00:00`);
       switch (date) {
         case 'today':
           return eventDate.getTime() === today.getTime();


### PR DESCRIPTION
## Summary
- ensure `filterEvents` parses event dates using local time so tests pass in any timezone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850d0c2483c8330af42a97e469b429b