### PR TITLE
Add privacy setting for profiles

### DIFF
--- a/SQL_SCHEMA.md
+++ b/SQL_SCHEMA.md
@@ -69,7 +69,8 @@ CREATE TABLE public.profiles (
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now(),
   phone varchar(20),
-  timezone varchar(50) DEFAULT 'Asia/Tokyo'
+  timezone varchar(50) DEFAULT 'Asia/Tokyo',
+  is_private boolean DEFAULT false
 );
 CREATE INDEX idx_profiles_user_id ON public.profiles(id);
 CREATE TRIGGER create_user_settings_trigger

--- a/supabase/migrations/20250617_add_is_private_to_profiles.sql
+++ b/supabase/migrations/20250617_add_is_private_to_profiles.sql
@@ -1,0 +1,3 @@
+-- Add is_private column to profiles
+ALTER TABLE public.profiles
+ADD COLUMN IF NOT EXISTS is_private boolean DEFAULT false;


### PR DESCRIPTION
## Summary
- add `is_private` column to the `profiles` table in SQL schema
- add migration to create the column

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e2243c148330bbc79eb9627d6e97