### PR TITLE
Add follow requests table

### DIFF
--- a/SQL_SCHEMA.md
+++ b/SQL_SCHEMA.md
@@ -134,7 +134,19 @@ CREATE TABLE public.follows (
 CREATE INDEX idx_follows_follower  ON public.follows(follower_id);
 CREATE INDEX idx_follows_following ON public.follows(following_id);
 
--- 4-6) Events
+-- 4-6) Follow Requests
+CREATE TABLE public.follow_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  requester_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  target_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  status varchar(20) DEFAULT 'pending',
+  created_at timestamptz DEFAULT now(),
+  CONSTRAINT follow_requests_requester_target_key UNIQUE (requester_id, target_id)
+);
+CREATE INDEX idx_follow_requests_requester ON public.follow_requests(requester_id);
+CREATE INDEX idx_follow_requests_target   ON public.follow_requests(target_id);
+
+-- 4-7) Events
 CREATE TABLE public.events (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   title text NOT NULL,
@@ -160,7 +172,7 @@ CREATE TRIGGER handle_events_updated_at
   BEFORE UPDATE ON public.events
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-7) Event Participants
+-- 4-8) Event Participants
 CREATE TABLE public.event_participants (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   event_id uuid REFERENCES public.events(id) ON DELETE CASCADE,
@@ -172,7 +184,7 @@ CREATE TABLE public.event_participants (
 CREATE INDEX idx_event_participants_event ON public.event_participants(event_id);
 CREATE INDEX idx_event_participants_user  ON public.event_participants(user_id);
 
--- 4-8) Blocked Users
+-- 4-9) Blocked Users
 CREATE TABLE public.blocked_users (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   blocker_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -183,7 +195,7 @@ CREATE TABLE public.blocked_users (
 CREATE INDEX idx_blocked_users_blocker_id ON public.blocked_users(blocker_id);
 CREATE INDEX idx_blocked_users_blocked_id ON public.blocked_users(blocked_id);
 
--- 4-9) Direct Messages
+-- 4-10) Direct Messages
 CREATE TABLE public.direct_messages (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   sender_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
@@ -197,7 +209,7 @@ CREATE INDEX idx_direct_messages_sender   ON public.direct_messages(sender_id);
 CREATE INDEX idx_direct_messages_receiver ON public.direct_messages(receiver_id);
 CREATE INDEX idx_direct_messages_created  ON public.direct_messages(created_at DESC);
 
--- 4-10) Projects
+-- 4-11) Projects
 CREATE TABLE public.projects (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -217,7 +229,7 @@ CREATE TRIGGER handle_projects_updated_at
   BEFORE UPDATE ON public.projects
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-11) Privacy Settings
+-- 4-12) Privacy Settings
 CREATE TABLE public.privacy_settings (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -237,7 +249,7 @@ CREATE TRIGGER update_privacy_settings_updated_at
   BEFORE UPDATE ON public.privacy_settings
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
--- 4-12) Posts
+-- 4-13) Posts
 CREATE TABLE public.posts (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -254,7 +266,7 @@ CREATE TRIGGER handle_posts_updated_at
   BEFORE UPDATE ON public.posts
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-13) Post Likes
+-- 4-14) Post Likes
 CREATE TABLE public.post_likes (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -265,7 +277,7 @@ CREATE TABLE public.post_likes (
 CREATE INDEX idx_post_likes_user_id ON public.post_likes(user_id);
 CREATE INDEX idx_post_likes_post_id ON public.post_likes(post_id);
 
--- 4-14) Post Comments
+-- 4-15) Post Comments
 CREATE TABLE public.post_comments (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -280,7 +292,7 @@ CREATE TRIGGER handle_post_comments_updated_at
   BEFORE UPDATE ON public.post_comments
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-15) Post Bookmarks
+-- 4-16) Post Bookmarks
 CREATE TABLE public.post_bookmarks (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -291,7 +303,7 @@ CREATE TABLE public.post_bookmarks (
 CREATE INDEX idx_post_bookmarks_user ON public.post_bookmarks(user_id);
 CREATE INDEX idx_post_bookmarks_post ON public.post_bookmarks(post_id);
 
--- 4-16) Notifications
+-- 4-17) Notifications
 CREATE TABLE public.notifications (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -305,7 +317,7 @@ CREATE TABLE public.notifications (
 CREATE INDEX idx_notifications_user ON public.notifications(user_id);
 CREATE INDEX idx_notifications_read ON public.notifications(is_read);
 
--- 4-17) Notification Settings
+-- 4-18) Notification Settings
 CREATE TABLE public.notification_settings (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -324,7 +336,7 @@ CREATE TRIGGER update_notification_settings_updated_at
   BEFORE UPDATE ON public.notification_settings
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
--- 4-18) User Sessions
+-- 4-19) User Sessions
 CREATE TABLE public.user_sessions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -340,7 +352,7 @@ CREATE TABLE public.user_sessions (
 );
 CREATE INDEX idx_user_sessions_user_id ON public.user_sessions(user_id);
 
--- 4-19) Startup Info
+-- 4-20) Startup Info
 CREATE TABLE public.startup_info (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
@@ -357,7 +369,7 @@ CREATE TRIGGER handle_startup_info_updated_at
   BEFORE UPDATE ON public.startup_info
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-20) Shared Files
+-- 4-21) Shared Files
 CREATE TABLE public.shared_files (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   name text NOT NULL,
@@ -370,7 +382,7 @@ CREATE TABLE public.shared_files (
   created_at timestamptz DEFAULT now()
 );
 
--- 4-21) Security Settings
+-- 4-22) Security Settings
 CREATE TABLE public.security_settings (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -387,7 +399,7 @@ CREATE TRIGGER update_security_settings_updated_at
   BEFORE UPDATE ON public.security_settings
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
--- 4-22) Push Subscriptions
+-- 4-23) Push Subscriptions
 CREATE TABLE public.push_subscriptions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
@@ -398,7 +410,7 @@ CREATE TABLE public.push_subscriptions (
 );
 CREATE INDEX idx_push_subscriptions_user_id ON public.push_subscriptions(user_id);
 
--- 4-23) Profile Embeddings
+-- 4-24) Profile Embeddings
 CREATE TABLE public.profile_embeddings (
   user_id uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
   embedding vector(1536)


### PR DESCRIPTION
## Summary
- add `follow_requests` table to SQL schema
- renumber later sections

## Testing
- `npm test`
- `npm run lint`
- `npx supabase start` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6850e225f858833087b07b923781ba30