### PR TITLE
Implement follow requests for private accounts

### DIFF
--- a/connections.html
+++ b/connections.html
@@ -46,6 +46,7 @@
 
       let currentUser = null;
       let followingSet = new Set();
+      let followRequestSet = new Set();
       const locationNames = {
         hokkaido: "北海道",
         aomori: "青森県",
@@ -104,6 +105,7 @@
         const view = params.get('view');
         if (!profileUser) return;
         await loadFollowingSet();
+        await loadFollowRequests();
         await loadFollowers(profileUser);
         await loadFollowing(profileUser);
         if (view === 'following') {
@@ -138,6 +140,14 @@
         followingSet = new Set((data || []).map((f) => f.following_id));
       }
 
+      async function loadFollowRequests() {
+        const { data } = await supabase
+          .from('follow_requests')
+          .select('following_id')
+          .eq('follower_id', currentUser.id);
+        followRequestSet = new Set((data || []).map((r) => r.following_id));
+      }
+
       async function loadFollowers(userId) {
         const { data } = await supabase
           .from('follows')
@@ -163,8 +173,9 @@
 
       function createCard(profile) {
         const isFollowing = followingSet.has(profile.id);
-        const btnClass = isFollowing ? 'text-gray-600 border-gray-600' : 'text-blue-600 border-blue-600';
-        const btnText = isFollowing ? 'フォロー中' : 'フォローする';
+        const isRequested = followRequestSet.has(profile.id);
+        const btnClass = isFollowing || isRequested ? 'text-gray-600 border-gray-600' : 'text-blue-600 border-blue-600';
+        const btnText = isFollowing ? 'フォロー中' : isRequested ? 'リクエスト済み' : 'フォローする';
         const showBtn = currentUser && currentUser.id !== profile.id;
         return `
           <div class="flex items-center space-x-4">
@@ -180,9 +191,26 @@
       async function toggleFollow(userId) {
         const button = document.querySelector(`[data-user-id="${userId}"]`);
         const isFollowing = followingSet.has(userId);
+        const isRequested = followRequestSet.has(userId);
         button.disabled = true;
-        if (isFollowing) {
-          const { error } = await supabase.from('follows').delete().eq('follower_id', currentUser.id).eq('following_id', userId);
+        if (isRequested) {
+          const { error } = await supabase
+            .from('follow_requests')
+            .delete()
+            .eq('follower_id', currentUser.id)
+            .eq('following_id', userId);
+          if (!error) {
+            followRequestSet.delete(userId);
+            button.textContent = 'フォローする';
+            button.classList.remove('text-gray-600', 'border-gray-600');
+            button.classList.add('text-blue-600', 'border-blue-600');
+          }
+        } else if (isFollowing) {
+          const { error } = await supabase
+            .from('follows')
+            .delete()
+            .eq('follower_id', currentUser.id)
+            .eq('following_id', userId);
           if (!error) {
             followingSet.delete(userId);
             button.textContent = 'フォローする';
@@ -190,19 +218,48 @@
             button.classList.add('text-blue-600', 'border-blue-600');
           }
         } else {
-          const { error } = await supabase.from('follows').insert({ follower_id: currentUser.id, following_id: userId });
-          if (!error) {
-            followingSet.add(userId);
-            button.textContent = 'フォロー中';
-            button.classList.remove('text-blue-600', 'border-blue-600');
-            button.classList.add('text-gray-600', 'border-gray-600');
-            await supabase.from('notifications').insert({
-              user_id: userId,
-              type: 'follow',
-              title: '新しいフォロワー',
-              content: `${document.getElementById('current-user-name').textContent}さんがあなたをフォローしました`,
-              related_id: currentUser.id,
+          const { data: target } = await supabase
+            .from('profiles')
+            .select('is_private')
+            .eq('id', userId)
+            .single();
+
+          if (target?.is_private) {
+            const { error } = await supabase.from('follow_requests').insert({
+              follower_id: currentUser.id,
+              following_id: userId,
             });
+            if (!error) {
+              followRequestSet.add(userId);
+              button.textContent = 'リクエスト済み';
+              button.classList.remove('text-blue-600', 'border-blue-600');
+              button.classList.add('text-gray-600', 'border-gray-600');
+              await supabase.from('notifications').insert({
+                user_id: userId,
+                type: 'follow_request',
+                title: 'フォローリクエスト',
+                content: `${document.getElementById('current-user-name').textContent}さんからフォローリクエストが届きました`,
+                related_id: currentUser.id,
+              });
+            }
+          } else {
+            const { error } = await supabase.from('follows').insert({
+              follower_id: currentUser.id,
+              following_id: userId,
+            });
+            if (!error) {
+              followingSet.add(userId);
+              button.textContent = 'フォロー中';
+              button.classList.remove('text-blue-600', 'border-blue-600');
+              button.classList.add('text-gray-600', 'border-gray-600');
+              await supabase.from('notifications').insert({
+                user_id: userId,
+                type: 'follow',
+                title: '新しいフォロワー',
+                content: `${document.getElementById('current-user-name').textContent}さんがあなたをフォローしました`,
+                related_id: currentUser.id,
+              });
+            }
           }
         }
         button.disabled = false;

--- a/notifications.html
+++ b/notifications.html
@@ -594,6 +594,23 @@
               : "";
             break;
 
+          case "follow_request":
+            const requester = relatedUsers.get(notification.related_id);
+            icon = requester
+              ? `<img loading="lazy" class="h-12 w-12 rounded-full object-cover" src="${
+                  requester.profile_image_url || "/api/placeholder/48/48"
+                }" alt="${requester.last_name} ${requester.first_name}">`
+              : `<div class="h-12 w-12 rounded-full bg-blue-100 flex items-center justify-center">
+                            <svg class="h-6 w-6 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                            </svg>
+                        </div>`;
+            content = notification.content;
+            actions = requester
+              ? `<a href="profile-detail.html?user=${notification.related_id}" class="border border-gray-300 text-gray-700 py-1 px-3 rounded-md text-xs font-medium hover:bg-gray-50 transition duration-200">プロフィールを見る</a>`
+              : "";
+            break;
+
           case "message":
             const sender = relatedUsers.get(notification.related_id);
             icon = sender

--- a/profile-detail.html
+++ b/profile-detail.html
@@ -405,6 +405,7 @@
       let profileUserData = null;
       let startupInfo = null;
       let isFollowing = false;
+      let isRequested = false;
       let followerCount = 0;
       let followingCount = 0;
       let projects = [];
@@ -653,6 +654,18 @@
           .single();
 
         isFollowing = !!follow;
+
+        if (!isFollowing) {
+          const { data: request } = await supabase
+            .from("follow_requests")
+            .select("*")
+            .eq("follower_id", currentUser.id)
+            .eq("following_id", profileUser)
+            .single();
+          isRequested = !!request;
+        } else {
+          isRequested = false;
+        }
         updateFollowButton();
       }
 
@@ -661,6 +674,10 @@
         const followBtn = document.getElementById("follow-btn");
         if (isFollowing) {
           followBtn.textContent = "フォロー中";
+          followBtn.classList.remove("bg-blue-600", "hover:bg-blue-700");
+          followBtn.classList.add("bg-gray-600", "hover:bg-gray-700");
+        } else if (isRequested) {
+          followBtn.textContent = "リクエスト済み";
           followBtn.classList.remove("bg-blue-600", "hover:bg-blue-700");
           followBtn.classList.add("bg-gray-600", "hover:bg-gray-700");
         } else {
@@ -1184,7 +1201,15 @@
         if (profileUser === currentUser.id) return;
 
         try {
-          if (isFollowing) {
+          if (isRequested) {
+            await supabase
+              .from("follow_requests")
+              .delete()
+              .eq("follower_id", currentUser.id)
+              .eq("following_id", profileUser);
+
+            isRequested = false;
+          } else if (isFollowing) {
             // アンフォロー
             await supabase
               .from("follows")
@@ -1195,23 +1220,45 @@
             isFollowing = false;
             followerCount--;
           } else {
-            // フォロー
-            await supabase.from("follows").insert({
-              follower_id: currentUser.id,
-              following_id: profileUser,
-            });
+            const { data: target } = await supabase
+              .from("profiles")
+              .select("is_private")
+              .eq("id", profileUser)
+              .single();
 
-            // 通知作成
-            await supabase.from("notifications").insert({
-              user_id: profileUser,
-              type: "follow",
-              title: "新しいフォロワー",
-              content: `${currentUserProfile.last_name} ${currentUserProfile.first_name}さんがあなたをフォローしました`,
-              related_id: currentUser.id,
-            });
+            if (target?.is_private) {
+              await supabase.from("follow_requests").insert({
+                follower_id: currentUser.id,
+                following_id: profileUser,
+              });
 
-            isFollowing = true;
-            followerCount++;
+              await supabase.from("notifications").insert({
+                user_id: profileUser,
+                type: "follow_request",
+                title: "フォローリクエスト",
+                content: `${currentUserProfile.last_name} ${currentUserProfile.first_name}さんからフォローリクエストが届きました`,
+                related_id: currentUser.id,
+              });
+
+              isRequested = true;
+            } else {
+              // フォロー
+              await supabase.from("follows").insert({
+                follower_id: currentUser.id,
+                following_id: profileUser,
+              });
+
+              await supabase.from("notifications").insert({
+                user_id: profileUser,
+                type: "follow",
+                title: "新しいフォロワー",
+                content: `${currentUserProfile.last_name} ${currentUserProfile.first_name}さんがあなたをフォローしました`,
+                related_id: currentUser.id,
+              });
+
+              isFollowing = true;
+              followerCount++;
+            }
           }
 
           updateFollowButton();

--- a/search.html
+++ b/search.html
@@ -885,6 +885,7 @@
       let totalResults = 0;
       let allUsers = [];
       let followingUsers = new Set();
+      let followRequests = new Set();
       const useInfiniteScroll = false; // toggle for infinite scrolling
       let isLoadingMore = false;
 
@@ -974,6 +975,7 @@
         currentPage = parseInt(params.get("page")) || 1;
         await checkAuth();
         await loadFollowingUsers();
+        await loadFollowRequests();
         setupMobileFilter();
         await performSearch();
       });
@@ -1021,6 +1023,17 @@
 
         if (data) {
           followingUsers = new Set(data.map((f) => f.following_id));
+        }
+      }
+
+      async function loadFollowRequests() {
+        const { data } = await supabase
+          .from("follow_requests")
+          .select("following_id")
+          .eq("follower_id", currentUser.id);
+
+        if (data) {
+          followRequests = new Set(data.map((r) => r.following_id));
         }
       }
 
@@ -1186,6 +1199,7 @@
       // ユーザーカードの作成
       function createUserCard(user) {
         const isFollowing = followingUsers.has(user.id);
+        const isRequested = followRequests.has(user.id);
 
         const card = document.createElement("div");
         card.className =
@@ -1226,8 +1240,10 @@
                       user.id
                     }')" data-user-id="${
           user.id
-        }" class="follow-button text-blue-600 border border-blue-600 rounded-md px-3 py-1 text-sm hover:bg-blue-50">
-                        ${isFollowing ? "フォロー中" : "フォローする"}
+        }" class="follow-button ${
+          isFollowing || isRequested ? 'text-gray-600 border-gray-600' : 'text-blue-600 border-blue-600'
+        } rounded-md px-3 py-1 text-sm hover:bg-blue-50">
+                        ${isFollowing ? "フォロー中" : isRequested ? "リクエスト済み" : "フォローする"}
                     </button>
                     <a href="profile-detail.html?user=${
                       user.id
@@ -1242,10 +1258,25 @@
       async function toggleFollow(userId) {
         const button = document.querySelector(`[data-user-id="${userId}"]`);
         const isFollowing = followingUsers.has(userId);
+        const isRequested = followRequests.has(userId);
 
         button.disabled = true;
 
-        if (isFollowing) {
+        if (isRequested) {
+          // リクエストキャンセル
+          const { error } = await supabase
+            .from("follow_requests")
+            .delete()
+            .eq("follower_id", currentUser.id)
+            .eq("following_id", userId);
+
+          if (!error) {
+            followRequests.delete(userId);
+            button.textContent = "フォローする";
+            button.classList.remove("text-gray-600", "border-gray-600");
+            button.classList.add("text-blue-600", "border-blue-600");
+          }
+        } else if (isFollowing) {
           // アンフォロー
           const { error } = await supabase
             .from("follows")
@@ -1258,26 +1289,52 @@
             button.textContent = "フォローする";
           }
         } else {
-          // フォロー
-          const { error } = await supabase.from("follows").insert({
-            follower_id: currentUser.id,
-            following_id: userId,
-          });
+          // 対象ユーザーのプライバシー設定取得
+          const { data: target } = await supabase
+            .from("profiles")
+            .select("is_private")
+            .eq("id", userId)
+            .single();
 
-          if (!error) {
-            followingUsers.add(userId);
-            button.textContent = "フォロー中";
-
-            // 通知を作成
-            await supabase.from("notifications").insert({
-              user_id: userId,
-              type: "follow",
-              title: "新しいフォロワー",
-              content: `${
-                document.getElementById("user-name").textContent
-              }さんがあなたをフォローしました`,
-              related_id: currentUser.id,
+          if (target?.is_private) {
+            // フォローリクエスト
+            const { error } = await supabase.from("follow_requests").insert({
+              follower_id: currentUser.id,
+              following_id: userId,
             });
+
+            if (!error) {
+              followRequests.add(userId);
+              button.textContent = "リクエスト済み";
+              button.classList.remove("text-blue-600", "border-blue-600");
+              button.classList.add("text-gray-600", "border-gray-600");
+              await supabase.from("notifications").insert({
+                user_id: userId,
+                type: "follow_request",
+                title: "フォローリクエスト",
+                content: `${document.getElementById("user-name").textContent}さんからフォローリクエストが届きました`,
+                related_id: currentUser.id,
+              });
+            }
+          } else {
+            // フォロー
+            const { error } = await supabase.from("follows").insert({
+              follower_id: currentUser.id,
+              following_id: userId,
+            });
+
+            if (!error) {
+              followingUsers.add(userId);
+              button.textContent = "フォロー中";
+
+              await supabase.from("notifications").insert({
+                user_id: userId,
+                type: "follow",
+                title: "新しいフォロワー",
+                content: `${document.getElementById("user-name").textContent}さんがあなたをフォローしました`,
+                related_id: currentUser.id,
+              });
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- handle follow requests in profile, search, and connections pages
- store request status and show "リクエスト済み" on request
- notify targets with `follow_request` notification type
- display follow request notifications

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e22722d48330ae572e0516acf709