### PR TITLE
Add follow request acceptance push notifications

### DIFF
--- a/notifications.html
+++ b/notifications.html
@@ -918,6 +918,35 @@
         });
 
         if (!error) {
+          // 承認通知を作成
+          const { data: notif } = await supabase
+            .from("notifications")
+            .insert({
+              user_id: userId,
+              type: "follow_request_accepted",
+              title: "フォロー承認",
+              content: `${userProfile.last_name} ${userProfile.first_name}さんがあなたのフォローリクエストを承認しました`,
+              related_id: currentUser.id,
+            })
+            .select()
+            .single();
+
+          // プッシュ通知を送信
+          if (notif) {
+            await fetch("/api/send_push", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                user_id: userId,
+                title: notif.title,
+                body: notif.content,
+                url: `profile-detail.html?user=${currentUser.id}`,
+                notification_id: notif.id,
+                event: "follow_request_accepted",
+              }),
+            });
+          }
+
           alert("フォローしました！");
           loadNotifications();
         }

--- a/server.js
+++ b/server.js
@@ -109,7 +109,7 @@ app.get('/api/recommendations', async (req, res) => {
 
 
 app.post('/api/send_push', async (req, res) => {
-  const { user_id, title, body, url, notification_id } = req.body;
+  const { user_id, title, body, url, notification_id, event } = req.body;
   if (!user_id) return res.status(400).json({ error: 'missing user_id' });
   if (!process.env.PUSH_VAPID_PUBLIC_KEY || !process.env.PUSH_VAPID_PRIVATE_KEY) {
     return res.json({ status: 'push disabled' });
@@ -127,7 +127,7 @@ app.post('/api/send_push', async (req, res) => {
       try {
         await webpush.sendNotification(
           subscription,
-          JSON.stringify({ title, body, url, id: notification_id })
+          JSON.stringify({ title, body, url, id: notification_id, event })
         );
       } catch (err) {
         console.error('push error', err);


### PR DESCRIPTION
## Summary
- send follow request accepted push notifications
- include event payload in push server endpoint

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e22ad6e083308d8ccd4b77ca24c2