### PR TITLE
Fix mobile menu toggle and header menu id

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -152,6 +152,8 @@
           <div class="flex md:hidden items-center">
             <button
               type="button"
+              aria-expanded="false"
+              aria-controls="mobile-menu"
               class="mobile-menu-button text-gray-500 hover:text-blue-600 focus:outline-none"
             >
               <svg
@@ -173,7 +175,7 @@
       </div>
 
       <!-- モバイルメニュー -->
-      <div class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
+      <div id="mobile-menu" class="mobile-menu hidden md:hidden bg-white border-t" role="menu">
         <a
           href="dashboard.html"
           class="block px-4 py-2 bg-blue-50 text-blue-600"

--- a/settings.html
+++ b/settings.html
@@ -1260,10 +1260,10 @@
         // モバイルメニュー
         document
           .querySelector(".mobile-menu-button")
-          .addEventListener("click", () => {
-          const menu = document.getElementById("mobile-menu");
-          const expanded = menu.classList.toggle("hidden") ? false : true;
-          this.setAttribute("aria-expanded", expanded);
+          .addEventListener("click", function () {
+            const menu = document.getElementById("mobile-menu");
+            const expanded = menu.classList.toggle("hidden") ? false : true;
+            this.setAttribute("aria-expanded", expanded);
           });
 
         // ウィンドウクリックでメニューを閉じる


### PR DESCRIPTION
## Summary
- fix header partial to expose `mobile-menu` id
- add ARIA attributes on mobile menu button
- ensure settings page uses proper function for menu toggle

## Testing
- `npm run lint` *(fails: couldn't find an eslint config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ec5d123c8330b8be42af30ac11c4