### PR TITLE
Add dark mode toggle to header

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -96,6 +96,15 @@
               ></span>
             </button>
 
+            <button id="theme-toggle" aria-label="Toggle dark mode" class="ml-3 p-2 rounded-md text-gray-500 hover:text-blue-600 focus:outline-none">
+              <svg class="h-6 w-6 dark:hidden" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/>
+              </svg>
+              <svg class="h-6 w-6 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"/>
+              </svg>
+            </button>
+
             <div class="ml-3 relative">
               <div class="flex items-center">
                 <button


### PR DESCRIPTION
## Summary
- include dark mode toggle in header partial
- keep user theme preference via `js/theme.js`
- confirm theme script loads on dashboard page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850f15754c88330a8ee7769f72e03e9