### PR TITLE
Fix event detail links in dashboard and notifications

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -913,7 +913,7 @@
             );
 
             return `
-                    <div class="px-6 py-4 flex items-start hover:bg-gray-50 transition duration-150 cursor-pointer" onclick="window.location.href='events.html?id=${
+                    <div class="px-6 py-4 flex items-start hover:bg-gray-50 transition duration-150 cursor-pointer" onclick="window.location.href='event-detail.html?event=${
                       event.id
                     }';">
                         <div class="flex-shrink-0 mr-4">

--- a/notifications.html
+++ b/notifications.html
@@ -646,11 +646,11 @@
             if (event && notification.type === "event") {
               actions = `
                             <button onclick="participateEvent('${notification.related_id}')" class="bg-blue-600 text-white py-1 px-3 rounded-md text-xs font-medium hover:bg-blue-700 transition duration-200">参加する</button>
-                            <a href="events.html?id=${notification.related_id}" class="border border-gray-300 text-gray-700 py-1 px-3 rounded-md text-xs font-medium hover:bg-gray-50 transition duration-200">詳細を見る</a>
+                            <a href="event-detail.html?event=${notification.related_id}" class="border border-gray-300 text-gray-700 py-1 px-3 rounded-md text-xs font-medium hover:bg-gray-50 transition duration-200">詳細を見る</a>
                             <button onclick="declineEvent('${notification.related_id}')" class="border border-gray-300 text-gray-700 py-1 px-3 rounded-md text-xs font-medium hover:bg-gray-50 transition duration-200">辞退する</button>
                         `;
             } else if (event) {
-              actions = `<a href="events.html?id=${notification.related_id}" class="text-blue-600 hover:text-blue-800 text-xs font-medium">イベント詳細を見る</a>`;
+              actions = `<a href="event-detail.html?event=${notification.related_id}" class="text-blue-600 hover:text-blue-800 text-xs font-medium">イベント詳細を見る</a>`;
             }
             break;
 


### PR DESCRIPTION
## Summary
- update dashboard event cards to open `event-detail.html?event=…`
- fix notification links to reference the new event detail page

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850f18f00948330abffba9f965b0994