### PR TITLE
Add daily event completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,12 @@ build step has been executed.
 5. **Dashboard Access** – Upon completion you return to the login screen with a
    success message. Signing in then takes you to `dashboard.html` where your
    personalized feed and messages appear.
+
+## Maintenance
+
+To automatically mark past events as completed, run the following command. This
+can be scheduled with cron for daily execution.
+
+```bash
+npm run complete-events
+```

--- a/complete-events.js
+++ b/complete-events.js
@@ -1,0 +1,45 @@
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
+);
+
+async function completePastEvents() {
+  const today = new Date().toISOString().split('T')[0];
+
+  const { data: events, error } = await supabase
+    .from('events')
+    .select('id')
+    .eq('status', 'scheduled')
+    .lt('event_date', today);
+
+  if (error) {
+    console.error('Failed to fetch events', error);
+    process.exit(1);
+  }
+
+  if (events.length === 0) {
+    console.log('No past scheduled events found.');
+    return;
+  }
+
+  const ids = events.map(e => e.id);
+  const { error: updateError } = await supabase
+    .from('events')
+    .update({ status: 'completed' })
+    .in('id', ids);
+
+  if (updateError) {
+    console.error('Failed to update events', updateError);
+    process.exit(1);
+  }
+
+  console.log(`Updated ${ids.length} events.`);
+}
+
+completePastEvents();
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "build": "node generate-config.js",
     "build:css": "tailwindcss -i ./styles/input.css -o ./styles/styles.css --minify",
-    "build:legacy": "node transpile-supabase.js && npx babel js --out-dir legacy/js --presets=@babel/preset-env"
+    "build:legacy": "node transpile-supabase.js && npx babel js --out-dir legacy/js --presets=@babel/preset-env",
+    "complete-events": "node complete-events.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.5",


### PR DESCRIPTION
## Summary
- add `complete-events.js` to mark past events as completed
- expose `npm run complete-events` helper
- document usage in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f19584048330b0c1696c283a3dbf