### PR TITLE
Add group message read tracking

### DIFF
--- a/SQL_SCHEMA.md
+++ b/SQL_SCHEMA.md
@@ -112,6 +112,16 @@ CREATE INDEX idx_group_messages_group   ON public.group_messages(group_id);
 CREATE INDEX idx_group_messages_created ON public.group_messages(created_at DESC);
 CREATE INDEX idx_group_messages_user    ON public.group_messages(user_id);
 
+-- 4-3b) Group Message Reads
+CREATE TABLE public.group_message_reads (
+  message_id uuid REFERENCES public.group_messages(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  read_at timestamptz DEFAULT now(),
+  PRIMARY KEY (message_id, user_id)
+);
+CREATE INDEX idx_group_message_reads_message ON public.group_message_reads(message_id);
+CREATE INDEX idx_group_message_reads_user    ON public.group_message_reads(user_id);
+
 -- 4-4) Group Members
 CREATE TABLE public.group_members (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/__tests__/groupReads.test.js
+++ b/__tests__/groupReads.test.js
@@ -1,0 +1,36 @@
+import { countUnread, countMessageReads, markAsRead } from '../js/groupReads.js';
+
+describe('group message read utilities', () => {
+  test('markAsRead adds missing records', () => {
+    const reads = [];
+    markAsRead(reads, ['m1', 'm2'], 'u1', 't1');
+    expect(reads).toEqual([
+      { message_id: 'm1', user_id: 'u1', read_at: 't1' },
+      { message_id: 'm2', user_id: 'u1', read_at: 't1' }
+    ]);
+    // calling again should not duplicate
+    markAsRead(reads, ['m1'], 'u1', 't2');
+    expect(reads.length).toBe(2);
+  });
+
+  test('countUnread counts per group', () => {
+    const messages = [
+      { id: 'm1', group_id: 'g1' },
+      { id: 'm2', group_id: 'g1' },
+      { id: 'm3', group_id: 'g2' }
+    ];
+    const reads = [{ message_id: 'm1', user_id: 'u1' }];
+    const result = countUnread(messages, reads, 'u1');
+    expect(result).toEqual({ g1: 1, g2: 1 });
+  });
+
+  test('countMessageReads aggregates correctly', () => {
+    const reads = [
+      { message_id: 'm1', user_id: 'u1' },
+      { message_id: 'm1', user_id: 'u2' },
+      { message_id: 'm2', user_id: 'u1' }
+    ];
+    const result = countMessageReads(reads);
+    expect(result).toEqual({ m1: 2, m2: 1 });
+  });
+});

--- a/groups.html
+++ b/groups.html
@@ -925,15 +925,26 @@
           const groupIds = memberGroups.map((g) => g.group_id);
           const unreadCounts = {};
           if (groupIds.length > 0) {
-            const { data: unreadMsgs } = await supabase
+            const { data: messages } = await supabase
               .from("group_messages")
-              .select("group_id")
-              .eq("is_read", false)
-              .eq("user_id", currentUser.id)
+              .select("id, group_id")
               .in("group_id", groupIds);
 
-            (unreadMsgs || []).forEach((m) => {
-              unreadCounts[m.group_id] = (unreadCounts[m.group_id] || 0) + 1;
+            const messageIds = (messages || []).map((m) => m.id);
+            let readIds = [];
+            if (messageIds.length > 0) {
+              const { data: reads } = await supabase
+                .from("group_message_reads")
+                .select("message_id")
+                .eq("user_id", currentUser.id)
+                .in("message_id", messageIds);
+              readIds = (reads || []).map((r) => r.message_id);
+            }
+            const readSet = new Set(readIds);
+            (messages || []).forEach((m) => {
+              if (!readSet.has(m.id)) {
+                unreadCounts[m.group_id] = (unreadCounts[m.group_id] || 0) + 1;
+              }
             });
           }
 
@@ -1117,6 +1128,23 @@
             .eq("group_id", groupId)
             .order("created_at", { ascending: true });
 
+          const messageIds = (messages || []).map((m) => m.id);
+          let readCounts = {};
+          if (messageIds.length > 0) {
+            const { data: reads } = await supabase
+              .from("group_message_reads")
+              .select("message_id")
+              .in("message_id", messageIds);
+            readCounts = (reads || []).reduce((acc, r) => {
+              acc[r.message_id] = (acc[r.message_id] || 0) + 1;
+              return acc;
+            }, {});
+          }
+
+          (messages || []).forEach((m) => {
+            m.read_count = readCounts[m.id] || 0;
+          });
+
           if (error) throw error;
 
           currentMessages = messages || [];
@@ -1201,6 +1229,9 @@
                       )
                       .join("")}
                     <p>${escapeHtml(message.content)}</p>
+                  </div>
+                  <div class="flex justify-end mt-1">
+                    <span class="text-xs text-gray-500">既読${message.read_count || 0}</span>
                   </div>
                 </div>
                 <img loading="lazy"
@@ -1584,12 +1615,20 @@
         const messageIds = currentMessages.map((m) => m.id);
         if (messageIds.length === 0) return;
 
-        await supabase
-          .from("group_messages")
-          .update({ is_read: true })
-          .in("id", messageIds)
+        const { data: existing } = await supabase
+          .from("group_message_reads")
+          .select("message_id")
           .eq("user_id", currentUser.id)
-          .eq("is_read", false);
+          .in("message_id", messageIds);
+
+        const existingIds = new Set((existing || []).map((r) => r.message_id));
+        const inserts = messageIds
+          .filter((id) => !existingIds.has(id))
+          .map((id) => ({ message_id: id, user_id: currentUser.id }));
+
+        if (inserts.length > 0) {
+          await supabase.from("group_message_reads").insert(inserts);
+        }
         loadGroups();
       }
 

--- a/js/groupReads.js
+++ b/js/groupReads.js
@@ -1,0 +1,26 @@
+export function countUnread(messages, reads, userId) {
+  const readSet = new Set(reads.filter(r => r.user_id === userId).map(r => r.message_id));
+  return messages.reduce((acc, msg) => {
+    if (!readSet.has(msg.id)) {
+      acc[msg.group_id] = (acc[msg.group_id] || 0) + 1;
+    }
+    return acc;
+  }, {});
+}
+
+export function countMessageReads(reads) {
+  return reads.reduce((acc, r) => {
+    acc[r.message_id] = (acc[r.message_id] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+export function markAsRead(reads, messageIds, userId, timestamp = new Date().toISOString()) {
+  messageIds.forEach(id => {
+    const exists = reads.some(r => r.message_id === id && r.user_id === userId);
+    if (!exists) {
+      reads.push({ message_id: id, user_id: userId, read_at: timestamp });
+    }
+  });
+  return reads;
+}

--- a/supabase/migrations/20250618_add_group_message_reads.sql
+++ b/supabase/migrations/20250618_add_group_message_reads.sql
@@ -1,0 +1,9 @@
+-- Track group message reads
+CREATE TABLE IF NOT EXISTS public.group_message_reads (
+  message_id uuid REFERENCES public.group_messages(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  read_at timestamptz DEFAULT now(),
+  PRIMARY KEY (message_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_group_message_reads_message ON public.group_message_reads(message_id);
+CREATE INDEX IF NOT EXISTS idx_group_message_reads_user ON public.group_message_reads(user_id);


### PR DESCRIPTION
## Summary
- add `group_message_reads` table to schema
- update migrations to create the table
- update group chat logic to calculate unread counts and mark reads
- show number of reads beside your sent messages
- add utilities and tests for group message read behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f1334460833085cdc4da4043a44b