### PR TITLE
Enable language switching on dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -458,6 +458,7 @@
       // ページ読み込み時の初期化
       window.addEventListener("load", async () => {
         await loadHeaderFooter();
+        if (window.initI18n) window.initI18n();
         // ヘッダー関連のイベント
         document
           .querySelector(".mobile-menu-button")
@@ -1171,6 +1172,7 @@
       // 初期ステップ表示
       showGuideStep(guideIndex);
     </script>
+    <script src="i18n.js"></script>
     <script src="js/theme.js"></script>
     <script src="accessibility.js"></script>
   </body>

--- a/i18n.js
+++ b/i18n.js
@@ -10,7 +10,7 @@ async function loadLanguage(lang) {
   document.documentElement.lang = lang;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function setupI18n() {
   const selector = document.getElementById('language-selector');
   const mobileSelector = document.getElementById('mobile-language');
   const initialLang = selector ? selector.value : 'ja';
@@ -22,4 +22,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   if (selector) selector.addEventListener('change', e => change(e.target.value));
   if (mobileSelector) mobileSelector.addEventListener('change', e => change(e.target.value));
-});
+}
+
+window.initI18n = setupI18n;
+window.addEventListener('DOMContentLoaded', setupI18n);

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,4 +5,13 @@
   "testimonials": "Testimonials",
   "login": "Login",
   "getStarted": "Get Started"
+  ,"home": "Home"
+  ,"search": "Search"
+  ,"messages": "Messages"
+  ,"groups": "Groups"
+  ,"events": "Events"
+  ,"guide": "Guide"
+  ,"profile": "Profile"
+  ,"settings": "Settings"
+  ,"logout": "Logout"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -5,4 +5,13 @@
   "testimonials": "利用者の声",
   "login": "ログイン",
   "getStarted": "無料で始める"
+  ,"home": "ホーム"
+  ,"search": "検索"
+  ,"messages": "メッセージ"
+  ,"groups": "グループ"
+  ,"events": "イベント"
+  ,"guide": "使い方ガイド"
+  ,"profile": "プロフィール"
+  ,"settings": "設定"
+  ,"logout": "ログアウト"
 }

--- a/partials/header.html
+++ b/partials/header.html
@@ -27,16 +27,19 @@
               <a
                 href="dashboard.html"
                 class="bg-blue-50 text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                data-i18n-key="home"
                 >ホーム</a
               >
               <a
                 href="search.html"
                 class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                data-i18n-key="search"
                 >検索</a
               >
               <a
                 href="messages.html"
                 class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium relative"
+                data-i18n-key="messages"
               >
                 メッセージ
                 <span
@@ -48,6 +51,7 @@
               <a
                 href="groups.html"
                 class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium relative"
+                data-i18n-key="groups"
               >
                 グループ
                 <span
@@ -59,12 +63,14 @@
               <a
                 href="events.html"
                 class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                data-i18n-key="events"
                 >イベント</a
               >
               <a
                 href="#"
                 id="guide-link"
                 class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium"
+                data-i18n-key="guide"
                 >使い方ガイド</a
               >
             </nav>
@@ -147,6 +153,11 @@
                 >
               </div>
             </div>
+            <label for="language-selector" class="sr-only">言語</label>
+            <select id="language-selector" class="ml-2 border rounded px-2 py-1 text-sm">
+              <option value="ja">日本語</option>
+              <option value="en">English</option>
+            </select>
           </div>
 
           <div class="flex md:hidden items-center">
@@ -180,30 +191,35 @@
           href="dashboard.html"
           class="block px-4 py-2 bg-blue-50 text-blue-600"
           role="menuitem"
+          data-i18n-key="home"
           >ホーム</a
         >
         <a
           href="search.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="search"
           >検索</a
         >
         <a
           href="messages.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="messages"
           >メッセージ</a
         >
         <a
           href="groups.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="groups"
           >グループ</a
         >
         <a
           href="events.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="events"
           >イベント</a
         >
         <a
@@ -211,6 +227,7 @@
           id="guide-link-mobile"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="guide"
           >使い方ガイド</a
         >
         <div class="border-t border-gray-200 my-1"></div>
@@ -218,19 +235,29 @@
           href="profile.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="profile"
           >プロフィール</a
         >
         <a
           href="settings.html"
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="settings"
           >設定</a
         >
         <a
           href="#"
           class="logout-link-mobile block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
+          data-i18n-key="logout"
           >ログアウト</a
         >
-      </div>
-    </header>
+          <div class="px-4 py-2">
+            <label for="mobile-language" class="sr-only">言語</label>
+            <select id="mobile-language" class="border rounded px-2 py-1 w-full text-sm">
+              <option value="ja">日本語</option>
+              <option value="en">English</option>
+            </select>
+          </div>
+        </div>
+      </header>


### PR DESCRIPTION
## Summary
- add desktop and mobile language selectors to `partials/header.html`
- extend translation dictionaries for navigation terms
- allow i18n initialization after partials load
- load `i18n.js` and initialize it on `dashboard.html`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6850f158b04883308eebd6d1f7df432d