### PR TITLE
Refactor follow logic

### DIFF
--- a/connections.html
+++ b/connections.html
@@ -40,9 +40,17 @@
       </div>
     </main>
 
-    <script>
+    <script type="module">
       const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
       const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+      const {
+        sendFollowRequest,
+        followUser,
+        unfollowUser,
+        cancelFollowRequest,
+        updateFollowButton,
+      } = await import('./js/follow.js');
 
       let currentUser = null;
       let followingSet = new Set();
@@ -198,29 +206,24 @@
         const isRequested = followRequestSet.has(userId);
         button.disabled = true;
         if (isRequested) {
-          const { error } = await supabase
-            .from('follow_requests')
-            .delete()
-            .eq('follower_id', currentUser.id)
-            .eq('following_id', userId);
+          const { error } = await cancelFollowRequest(
+            supabase,
+            currentUser.id,
+            userId
+          );
           if (!error) {
             followRequestSet.delete(userId);
-            button.textContent = 'フォローする';
-            button.classList.remove('follow-requested');
-            button.classList.remove('text-gray-600', 'border-gray-600');
-            button.classList.add('text-blue-600', 'border-blue-600');
+            updateFollowButton(button, false, false);
           }
         } else if (isFollowing) {
-          const { error } = await supabase
-            .from('follows')
-            .delete()
-            .eq('follower_id', currentUser.id)
-            .eq('following_id', userId);
+          const { error } = await unfollowUser(
+            supabase,
+            currentUser.id,
+            userId
+          );
           if (!error) {
             followingSet.delete(userId);
-            button.textContent = 'フォローする';
-            button.classList.remove('text-gray-600', 'border-gray-600');
-            button.classList.add('text-blue-600', 'border-blue-600');
+            updateFollowButton(button, false, false);
           }
         } else {
           const { data: target } = await supabase
@@ -230,16 +233,14 @@
             .single();
 
           if (target?.is_private) {
-            const { error } = await supabase.from('follow_requests').insert({
-              follower_id: currentUser.id,
-              following_id: userId,
-            });
+            const { error } = await sendFollowRequest(
+              supabase,
+              currentUser.id,
+              userId
+            );
             if (!error) {
               followRequestSet.add(userId);
-              button.textContent = 'リクエスト済み';
-              button.classList.remove('text-blue-600', 'border-blue-600');
-              button.classList.add('follow-requested');
-              button.classList.add('text-gray-600', 'border-gray-600');
+              updateFollowButton(button, false, true);
               await supabase.from('notifications').insert({
                 user_id: userId,
                 type: 'follow_request',
@@ -249,15 +250,14 @@
               });
             }
           } else {
-            const { error } = await supabase.from('follows').insert({
-              follower_id: currentUser.id,
-              following_id: userId,
-            });
+            const { error } = await followUser(
+              supabase,
+              currentUser.id,
+              userId
+            );
             if (!error) {
               followingSet.add(userId);
-              button.textContent = 'フォロー中';
-              button.classList.remove('text-blue-600', 'border-blue-600');
-              button.classList.add('text-gray-600', 'border-gray-600');
+              updateFollowButton(button, true, false);
               await supabase.from('notifications').insert({
                 user_id: userId,
                 type: 'follow',

--- a/js/follow.js
+++ b/js/follow.js
@@ -1,0 +1,85 @@
+export async function checkFollowStatus(supabase, followerId, followingId) {
+  const { data: follow } = await supabase
+    .from('follows')
+    .select('*')
+    .eq('follower_id', followerId)
+    .eq('following_id', followingId)
+    .single();
+  const isFollowing = !!follow;
+  let isRequested = false;
+  if (!isFollowing) {
+    const { data: request } = await supabase
+      .from('follow_requests')
+      .select('*')
+      .eq('follower_id', followerId)
+      .eq('following_id', followingId)
+      .single();
+    isRequested = !!request;
+  }
+  return { isFollowing, isRequested };
+}
+
+export async function sendFollowRequest(supabase, followerId, followingId) {
+  return supabase.from('follow_requests').insert({
+    follower_id: followerId,
+    following_id: followingId,
+  });
+}
+
+export async function followUser(supabase, followerId, followingId) {
+  return supabase.from('follows').insert({
+    follower_id: followerId,
+    following_id: followingId,
+  });
+}
+
+export async function unfollowUser(supabase, followerId, followingId) {
+  return supabase
+    .from('follows')
+    .delete()
+    .eq('follower_id', followerId)
+    .eq('following_id', followingId);
+}
+
+export async function cancelFollowRequest(supabase, followerId, followingId) {
+  return supabase
+    .from('follow_requests')
+    .delete()
+    .eq('follower_id', followerId)
+    .eq('following_id', followingId);
+}
+
+export function updateFollowButton(button, isFollowing, isRequested) {
+  if (!button) return;
+  const isProfileStyle = button.dataset.style === 'profile';
+  if (isProfileStyle) {
+    if (isFollowing) {
+      button.textContent = 'フォロー中';
+      button.classList.remove('bg-blue-600', 'hover:bg-blue-700', 'follow-requested');
+      button.classList.add('bg-gray-600', 'hover:bg-gray-700');
+    } else if (isRequested) {
+      button.textContent = 'リクエスト済み';
+      button.classList.remove('bg-blue-600', 'hover:bg-blue-700');
+      button.classList.add('bg-gray-600', 'hover:bg-gray-700', 'follow-requested');
+    } else {
+      button.textContent = 'フォローする';
+      button.classList.remove('bg-gray-600', 'hover:bg-gray-700', 'follow-requested');
+      button.classList.add('bg-blue-600', 'hover:bg-blue-700');
+    }
+  } else {
+    if (isFollowing) {
+      button.textContent = 'フォロー中';
+      button.classList.remove('follow-requested', 'text-blue-600', 'border-blue-600');
+      button.classList.add('text-gray-600', 'border-gray-600');
+    } else if (isRequested) {
+      button.textContent = 'リクエスト済み';
+      button.classList.remove('text-blue-600', 'border-blue-600');
+      button.classList.add('follow-requested', 'text-gray-600', 'border-gray-600');
+    } else {
+      button.textContent = 'フォローする';
+      button.classList.remove('follow-requested', 'text-gray-600', 'border-gray-600');
+      button.classList.add('text-blue-600', 'border-blue-600');
+    }
+  }
+  button.disabled = false;
+}

--- a/profile-detail.html
+++ b/profile-detail.html
@@ -26,7 +26,7 @@
   </head>
   <body class="bg-gray-50 min-h-screen">
     <!-- ヘッダー -->
-    <script>
+    <script type="module">
       const hXhr = new XMLHttpRequest();
       hXhr.open("GET", "partials/header.html", false);
       hXhr.send(null);
@@ -107,6 +107,7 @@
               <div class="mt-4 sm:mt-0 flex space-x-2">
                 <button
                   id="follow-btn"
+                  data-style="profile"
                   class="bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 transition duration-200"
                 >
                   <span class="hidden sm:inline">フォローする</span>
@@ -398,6 +399,15 @@
         SUPABASE_ANON_KEY
       );
 
+      const {
+        checkFollowStatus: checkFollowStatusFn,
+        sendFollowRequest,
+        followUser,
+        unfollowUser,
+        cancelFollowRequest,
+        updateFollowButton,
+      } = await import('./js/follow.js');
+
       // グローバル変数
       let currentUser = null;
       let currentUserProfile = null;
@@ -646,46 +656,21 @@
           return;
         }
 
-        const { data: follow } = await supabase
-          .from("follows")
-          .select("*")
-          .eq("follower_id", currentUser.id)
-          .eq("following_id", profileUser)
-          .single();
-
-        isFollowing = !!follow;
-
-        if (!isFollowing) {
-          const { data: request } = await supabase
-            .from("follow_requests")
-            .select("*")
-            .eq("follower_id", currentUser.id)
-            .eq("following_id", profileUser)
-            .single();
-          isRequested = !!request;
-        } else {
-          isRequested = false;
-        }
-        updateFollowButton();
+        const status = await checkFollowStatusFn(
+          supabase,
+          currentUser.id,
+          profileUser
+        );
+        isFollowing = status.isFollowing;
+        isRequested = status.isRequested;
+        updateFollowButton(
+          document.getElementById("follow-btn"),
+          isFollowing,
+          isRequested
+        );
       }
 
-      // フォローボタン更新
-      function updateFollowButton() {
-        const followBtn = document.getElementById("follow-btn");
-        if (isFollowing) {
-          followBtn.textContent = "フォロー中";
-          followBtn.classList.remove("bg-blue-600", "hover:bg-blue-700", "follow-requested");
-          followBtn.classList.add("bg-gray-600", "hover:bg-gray-700");
-        } else if (isRequested) {
-          followBtn.textContent = "リクエスト済み";
-          followBtn.classList.remove("bg-blue-600", "hover:bg-blue-700");
-          followBtn.classList.add("bg-gray-600", "hover:bg-gray-700", "follow-requested");
-        } else {
-          followBtn.textContent = "フォローする";
-          followBtn.classList.remove("bg-gray-600", "hover:bg-gray-700", "follow-requested");
-          followBtn.classList.add("bg-blue-600", "hover:bg-blue-700");
-        }
-      }
+      // フォローボタン更新関数は follow.js から読み込み
 
       // つながり統計読み込み
       async function loadConnectionStats() {
@@ -1201,22 +1186,14 @@
         if (profileUser === currentUser.id) return;
 
         try {
-          if (isRequested) {
-            await supabase
-              .from("follow_requests")
-              .delete()
-              .eq("follower_id", currentUser.id)
-              .eq("following_id", profileUser);
+          const button = document.getElementById("follow-btn");
+          button.disabled = true;
 
+          if (isRequested) {
+            await cancelFollowRequest(supabase, currentUser.id, profileUser);
             isRequested = false;
           } else if (isFollowing) {
-            // アンフォロー
-            await supabase
-              .from("follows")
-              .delete()
-              .eq("follower_id", currentUser.id)
-              .eq("following_id", profileUser);
-
+            await unfollowUser(supabase, currentUser.id, profileUser);
             isFollowing = false;
             followerCount--;
           } else {
@@ -1227,10 +1204,7 @@
               .single();
 
             if (target?.is_private) {
-              await supabase.from("follow_requests").insert({
-                follower_id: currentUser.id,
-                following_id: profileUser,
-              });
+              await sendFollowRequest(supabase, currentUser.id, profileUser);
 
               await supabase.from("notifications").insert({
                 user_id: profileUser,
@@ -1242,11 +1216,7 @@
 
               isRequested = true;
             } else {
-              // フォロー
-              await supabase.from("follows").insert({
-                follower_id: currentUser.id,
-                following_id: profileUser,
-              });
+              await followUser(supabase, currentUser.id, profileUser);
 
               await supabase.from("notifications").insert({
                 user_id: profileUser,
@@ -1261,9 +1231,10 @@
             }
           }
 
-          updateFollowButton();
+          updateFollowButton(button, isFollowing, isRequested);
           await loadConnections(); // つながり情報を更新
           await loadConnectionStats();
+          button.disabled = false;
         } catch (error) {
           console.error("Error toggling follow:", error);
           alert("フォロー状態の変更に失敗しました");

--- a/search.html
+++ b/search.html
@@ -870,13 +870,21 @@
       </div>
     </div>
 
-    <script>
+    <script type="module">
       // Supabase設定
       const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
       const supabase = window.supabase.createClient(
         SUPABASE_URL,
         SUPABASE_ANON_KEY
       );
+
+      const {
+        sendFollowRequest,
+        followUser,
+        unfollowUser,
+        cancelFollowRequest,
+        updateFollowButton,
+      } = await import('./js/follow.js');
       
       // グローバル変数
       let currentUser = null;
@@ -1267,34 +1275,28 @@
         button.disabled = true;
 
         if (isRequested) {
-          // リクエストキャンセル
-          const { error } = await supabase
-            .from("follow_requests")
-            .delete()
-            .eq("follower_id", currentUser.id)
-            .eq("following_id", userId);
+          const { error } = await cancelFollowRequest(
+            supabase,
+            currentUser.id,
+            userId
+          );
 
           if (!error) {
             followRequests.delete(userId);
-            button.textContent = "フォローする";
-            button.classList.remove("follow-requested");
-            button.classList.remove("text-gray-600", "border-gray-600");
-            button.classList.add("text-blue-600", "border-blue-600");
+            updateFollowButton(button, false, false);
           }
         } else if (isFollowing) {
-          // アンフォロー
-          const { error } = await supabase
-            .from("follows")
-            .delete()
-            .eq("follower_id", currentUser.id)
-            .eq("following_id", userId);
+          const { error } = await unfollowUser(
+            supabase,
+            currentUser.id,
+            userId
+          );
 
           if (!error) {
             followingUsers.delete(userId);
-            button.textContent = "フォローする";
+            updateFollowButton(button, false, false);
           }
         } else {
-          // 対象ユーザーのプライバシー設定取得
           const { data: target } = await supabase
             .from("profiles")
             .select("is_private")
@@ -1302,18 +1304,15 @@
             .single();
 
           if (target?.is_private) {
-            // フォローリクエスト
-            const { error } = await supabase.from("follow_requests").insert({
-              follower_id: currentUser.id,
-              following_id: userId,
-            });
+            const { error } = await sendFollowRequest(
+              supabase,
+              currentUser.id,
+              userId
+            );
 
             if (!error) {
               followRequests.add(userId);
-              button.textContent = "リクエスト済み";
-              button.classList.remove("text-blue-600", "border-blue-600");
-              button.classList.add("follow-requested");
-              button.classList.add("text-gray-600", "border-gray-600");
+              updateFollowButton(button, false, true);
               await supabase.from("notifications").insert({
                 user_id: userId,
                 type: "follow_request",
@@ -1323,15 +1322,15 @@
               });
             }
           } else {
-            // フォロー
-            const { error } = await supabase.from("follows").insert({
-              follower_id: currentUser.id,
-              following_id: userId,
-            });
+            const { error } = await followUser(
+              supabase,
+              currentUser.id,
+              userId
+            );
 
             if (!error) {
               followingUsers.add(userId);
-              button.textContent = "フォロー中";
+              updateFollowButton(button, true, false);
 
               await supabase.from("notifications").insert({
                 user_id: userId,


### PR DESCRIPTION
## Summary
- factor out follow-related helpers into `js/follow.js`
- load the follow helpers in profile, search and connections pages
- use the shared helpers for follow state and button updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f1273cdc83308f5e945d32455902