### PR TITLE
Add post feed to dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -325,6 +325,22 @@
             </div>
           </div>
         </div>
+
+        <!-- 最近の投稿 -->
+        <div class="bg-white rounded-lg shadow-sm overflow-hidden">
+          <div class="px-6 py-4 border-b border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-800">最近の投稿</h2>
+          </div>
+          <div id="dashboard-posts" class="divide-y divide-gray-200">
+            <div class="px-6 py-8 text-center text-gray-500 skeleton">
+              <div class="h-4 bg-gray-200 rounded w-3/4 mx-auto mb-2"></div>
+              <div class="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div>
+            </div>
+          </div>
+          <div class="px-6 py-3 bg-gray-50 text-center">
+            <a href="posts.html" class="text-sm text-blue-600 hover:underline">もっと見る</a>
+          </div>
+        </div>
       </div>
   </main>
 
@@ -631,6 +647,7 @@
           loadMessages(),
           loadGroups(),
           loadEvents(),
+          loadPosts(),
           loadStats(),
           loadRecommendedUsers(),
         ]);
@@ -959,6 +976,70 @@
                         </div>
                     </div>
                 `;
+          })
+          .join("");
+      }
+
+      // 投稿読み込み
+      async function loadPosts() {
+        const { data: follows } = await supabase
+          .from("follows")
+          .select("following_id")
+          .eq("follower_id", currentUser.id);
+
+        const ids = follows ? follows.map((f) => f.following_id) : [];
+        const container = document.getElementById("dashboard-posts");
+
+        if (ids.length === 0) {
+          container.innerHTML = `
+                    <div class="px-6 py-8 text-center text-gray-500">
+                        <p class="text-sm">まだ投稿がありません</p>
+                    </div>
+                `;
+          return;
+        }
+
+        const { data: posts } = await supabase
+          .from("posts")
+          .select(
+            "*, profiles(id, first_name, last_name, profile_image_url)"
+          )
+          .in("user_id", ids)
+          .order("created_at", { ascending: false })
+          .limit(5);
+
+        if (!posts || posts.length === 0) {
+          container.innerHTML = `
+                    <div class="px-6 py-8 text-center text-gray-500">
+                        <p class="text-sm">まだ投稿がありません</p>
+                    </div>
+                `;
+          return;
+        }
+
+        container.innerHTML = posts
+          .map((post) => {
+            const images = (post.image_urls || [])
+              .map(
+                (url) => `<img loading="lazy" src="${url}" class="mt-2 rounded-md">`
+              )
+              .join("");
+            return `
+                <div class="px-6 py-4 flex items-start space-x-3 hover:bg-gray-50 cursor-pointer" onclick="window.location.href='profile-detail.html?user=${post.user_id}'">
+                    <img loading="lazy" class="h-8 w-8 rounded-full object-cover" src="${
+                      post.profiles?.profile_image_url || "/api/placeholder/32/32"
+                    }" alt="${post.profiles?.last_name || ""} ${
+              post.profiles?.first_name || ""
+            }">
+                    <div class="flex-1">
+                        <p class="font-medium text-gray-900">${post.profiles?.last_name || ""} ${post.profiles?.first_name || ""}</p>
+                        <p class="whitespace-pre-wrap">${post.content}</p>
+                        ${images}
+                        <p class="text-xs text-gray-500 mt-1">${new Date(
+                          post.created_at
+                        ).toLocaleString("ja-JP")}</p>
+                    </div>
+                </div>`;
           })
           .join("");
       }

--- a/posts.html
+++ b/posts.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
+    <title>投稿一覧 - スタートアップコネクト</title>
+    <link rel="stylesheet" href="styles/styles.css" />
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="config.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        font-family: "Noto Sans JP", sans-serif;
+      }
+    </style>
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div id="header-placeholder"></div>
+    <script src="js/loadPartials.js"></script>
+
+    <main class="max-w-3xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      <h1 class="text-2xl font-bold text-gray-800 mb-6">投稿一覧</h1>
+      <div id="posts-container" class="bg-white rounded-lg divide-y divide-gray-200">
+        <div class="px-6 py-8 text-center text-gray-500">
+          <div class="h-4 bg-gray-200 rounded w-3/4 mx-auto mb-2"></div>
+          <div class="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div>
+        </div>
+      </div>
+    </main>
+
+    <div id="footer-placeholder"></div>
+
+    <script>
+      const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
+      const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+      let currentUser = null;
+      let pageUser = null;
+
+      window.addEventListener("load", async () => {
+        await loadHeaderFooter();
+        const params = new URLSearchParams(window.location.search);
+        pageUser = params.get("user");
+        await checkAuth();
+        await loadPosts();
+      });
+
+      async function checkAuth() {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+          window.location.href = "login.html";
+          return;
+        }
+        currentUser = user;
+      }
+
+      async function loadPosts() {
+        const container = document.getElementById("posts-container");
+
+        let query = supabase
+          .from("posts")
+          .select("*, profiles(id, first_name, last_name, profile_image_url)")
+          .order("created_at", { ascending: false });
+
+        if (pageUser) {
+          query = query.eq("user_id", pageUser);
+        } else {
+          const { data: follows } = await supabase
+            .from("follows")
+            .select("following_id")
+            .eq("follower_id", currentUser.id);
+          const ids = follows ? follows.map((f) => f.following_id) : [];
+          if (ids.length === 0) {
+            container.innerHTML =
+              '<div class="px-6 py-8 text-center text-gray-500"><p class="text-sm">まだ投稿がありません</p></div>';
+            return;
+          }
+          query = query.in("user_id", ids);
+        }
+
+        const { data: posts } = await query.limit(20);
+
+        if (!posts || posts.length === 0) {
+          container.innerHTML =
+            '<div class="px-6 py-8 text-center text-gray-500"><p class="text-sm">まだ投稿がありません</p></div>';
+          return;
+        }
+
+        container.innerHTML = posts
+          .map((post) => {
+            const images = (post.image_urls || [])
+              .map((url) => `<img loading="lazy" src="${url}" class="mt-2 rounded-md">`)
+              .join("");
+            return `
+          <div class="px-6 py-4">
+            <div class="flex items-start space-x-3">
+              <img loading="lazy" class="h-8 w-8 rounded-full object-cover" src="${
+                post.profiles?.profile_image_url || "/api/placeholder/32/32"
+              }" alt="${post.profiles?.last_name || ""} ${post.profiles?.first_name || ""}">
+              <div class="flex-1">
+                <a href="profile-detail.html?user=${post.user_id}" class="font-medium text-gray-900 hover:underline">${
+              post.profiles?.last_name || ""
+            } ${post.profiles?.first_name || ""}</a>
+                <p class="whitespace-pre-wrap mt-1">${post.content}</p>
+                ${images}
+                <p class="text-xs text-gray-500 mt-1">${new Date(post.created_at).toLocaleString("ja-JP")}</p>
+              </div>
+            </div>
+          </div>`;
+          })
+          .join("");
+      }
+    </script>
+    <script src="js/theme.js"></script>
+    <script src="accessibility.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- show recent followed users' posts on dashboard
- fetch followed posts and show limited feed
- link to new posts page for more
- implement standalone posts page to view timeline

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f15a5b108330aeada003a1fd50b4