### PR TITLE
Add request badge for new follow requests

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -629,6 +629,7 @@
         await Promise.all([
           loadNotifications(),
           loadMessages(),
+          loadFollowRequestCount(),
           loadGroups(),
           loadEvents(),
           loadStats(),
@@ -778,6 +779,22 @@
             `
           )
           .join("");
+      }
+
+      // フォローリクエスト数読み込み
+      async function loadFollowRequestCount() {
+        const { count } = await supabase
+          .from("follow_requests")
+          .select("*", { count: "exact", head: true })
+          .eq("target_id", currentUser.id)
+          .eq("status", "pending");
+        const badge = document.getElementById("request-badge");
+        if (count && count > 0) {
+          badge.classList.remove("hidden");
+          badge.textContent = count;
+        } else {
+          badge.classList.add("hidden");
+        }
       }
 
       // グループ読み込み
@@ -1103,6 +1120,26 @@
             (payload) => {
               loadMessages();
               const badge = document.getElementById("message-badge");
+              badge.classList.remove("hidden");
+              badge.textContent = parseInt(badge.textContent || 0) + 1;
+            }
+          )
+          .subscribe();
+
+        // フォローリクエストのリアルタイム監視
+        supabase
+          .channel("dashboard-requests")
+          .on(
+            "postgres_changes",
+            {
+              event: "INSERT",
+              schema: "public",
+              table: "follow_requests",
+              filter: `target_id=eq.${currentUser.id}`,
+            },
+            (payload) => {
+              loadFollowRequestCount();
+              const badge = document.getElementById("request-badge");
               badge.classList.remove("hidden");
               badge.textContent = parseInt(badge.textContent || 0) + 1;
             }

--- a/notifications.html
+++ b/notifications.html
@@ -319,6 +319,7 @@
       window.addEventListener("load", async () => {
         await checkAuth();
         await loadNotifications();
+        await loadFollowRequestCount();
         setupRealtimeSubscriptions();
         updateUnreadBadges();
       });
@@ -387,6 +388,22 @@
 
         // フィルタリングと表示
         applyFilter();
+      }
+
+      // フォローリクエスト数読み込み
+      async function loadFollowRequestCount() {
+        const { count } = await supabase
+          .from("follow_requests")
+          .select("*", { count: "exact", head: true })
+          .eq("target_id", currentUser.id)
+          .eq("status", "pending");
+        const badge = document.getElementById("request-badge");
+        if (count && count > 0) {
+          badge.classList.remove("hidden");
+          badge.textContent = count;
+        } else {
+          badge.classList.add("hidden");
+        }
       }
 
       // 関連エンティティ読み込み
@@ -893,6 +910,22 @@
             async (payload) => {
               await loadNotifications();
               updateUnreadBadges();
+            }
+          )
+          .subscribe();
+
+        supabase
+          .channel("requests-channel")
+          .on(
+            "postgres_changes",
+            {
+              event: "INSERT",
+              schema: "public",
+              table: "follow_requests",
+              filter: `target_id=eq.${currentUser.id}`,
+            },
+            async (payload) => {
+              await loadFollowRequestCount();
             }
           )
           .subscribe();

--- a/partials/header.html
+++ b/partials/header.html
@@ -46,6 +46,17 @@
                 >
               </a>
               <a
+                href="connection-requests.html"
+                class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium relative"
+              >
+                リクエスト
+                <span
+                  id="request-badge"
+                  class="hidden absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center"
+                  >0</span
+                >
+              </a>
+              <a
                 href="groups.html"
                 class="text-gray-500 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium relative"
               >
@@ -193,6 +204,12 @@
           class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
           role="menuitem"
           >メッセージ</a
+        >
+        <a
+          href="connection-requests.html"
+          class="block px-4 py-2 text-gray-500 hover:bg-gray-100"
+          role="menuitem"
+          >リクエスト</a
         >
         <a
           href="groups.html"


### PR DESCRIPTION
## Summary
- show pending follow request badge in the header
- fetch request count from `follow_requests`
- update dashboards and notifications pages in real-time when new requests arrive

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f16135c483308fb443ad8e2899d5