### PR TITLE
Add push registration check on dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -44,9 +44,15 @@
         left: 1.5rem;
         border-width: 8px;
         border-style: solid;
-        border-color: #f3f4f6 transparent transparent transparent;
+    border-color: #f3f4f6 transparent transparent transparent;
       }
     </style>
+    <script type="module">
+      import { showToast } from "./js/toast.js";
+      import { registerPush } from "./js/push.js";
+      window.showToast = showToast;
+      window.registerPush = registerPush;
+    </script>
   </head>
   <body class="bg-gray-50 dark:bg-dark-bg dark:text-dark-text min-h-screen">
     <!-- ヘッダー -->
@@ -525,6 +531,23 @@
         await checkAuth();
         await loadDashboardData();
         setupRealtimeSubscriptions();
+
+        if (window.registerPush && window.__ENV__ && window.__ENV__.PUSH_VAPID_PUBLIC_KEY) {
+          const { data: subs } = await supabase
+            .from("push_subscriptions")
+            .select("id")
+            .eq("user_id", currentUser.id);
+          if (!subs || subs.length === 0) {
+            if (Notification.permission === "granted") {
+              await window.registerPush(currentUser.id);
+            } else if (window.showToast) {
+              window.showToast(
+                "通知が無効です。設定から有効にしてください。",
+                "info"
+              );
+            }
+          }
+        }
 
         if (!localStorage.getItem("introShown")) {
           openModal("intro-modal");

--- a/js/push.js
+++ b/js/push.js
@@ -1,0 +1,28 @@
+/* global supabase */
+export async function registerPush(userId) {
+  if (!('serviceWorker' in navigator)) return;
+  if (!window.__ENV__ || !window.__ENV__.PUSH_VAPID_PUBLIC_KEY) return;
+  try {
+    const reg = await navigator.serviceWorker.register('sw.js');
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') return;
+    const sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: window.__ENV__.PUSH_VAPID_PUBLIC_KEY,
+    });
+    const p256dh = btoa(
+      String.fromCharCode(...new Uint8Array(sub.getKey('p256dh')))
+    );
+    const auth = btoa(
+      String.fromCharCode(...new Uint8Array(sub.getKey('auth')))
+    );
+    await supabase.from('push_subscriptions').upsert({
+      user_id: userId,
+      endpoint: sub.endpoint,
+      p256dh,
+      auth,
+    });
+  } catch (e) {
+    console.warn('push registration failed', e);
+  }
+}

--- a/login.html
+++ b/login.html
@@ -26,7 +26,9 @@
     </style>
     <script type="module">
       import { showToast } from "./js/toast.js";
+      import { registerPush } from "./js/push.js";
       window.showToast = showToast;
+      window.registerPush = registerPush;
     </script>
   </head>
   <body class="bg-gray-50 dark:bg-dark-bg dark:text-dark-text">
@@ -450,31 +452,6 @@
           successDiv.classList.add("hidden");
         }, 5000);
       }
-
-      async function registerPush(userId) {
-        if (!('serviceWorker' in navigator)) return;
-        if (!window.__ENV__ || !window.__ENV__.PUSH_VAPID_PUBLIC_KEY) return;
-        try {
-          const reg = await navigator.serviceWorker.register('sw.js');
-          const permission = await Notification.requestPermission();
-          if (permission !== 'granted') return;
-          const sub = await reg.pushManager.subscribe({
-            userVisibleOnly: true,
-            applicationServerKey: window.__ENV__.PUSH_VAPID_PUBLIC_KEY,
-          });
-          const p256dh = btoa(String.fromCharCode(...new Uint8Array(sub.getKey('p256dh'))));
-          const auth = btoa(String.fromCharCode(...new Uint8Array(sub.getKey('auth'))));
-          await supabase.from('push_subscriptions').upsert({
-            user_id: userId,
-            endpoint: sub.endpoint,
-            p256dh,
-            auth,
-          });
-        } catch (e) {
-          console.warn('push registration failed', e);
-        }
-      }
-
       async function recordSession(userId, token) {
         try {
           let ip = null;


### PR DESCRIPTION
## Summary
- extract push registration logic into `js/push.js`
- import new module in login/dashboard pages
- automatically register for push on dashboard when missing
- notify users to enable notifications if permission denied

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850f16345b88330a505019878278a4e