### PR TITLE
Add date/time validation for events

### DIFF
--- a/event-detail.html
+++ b/event-detail.html
@@ -174,6 +174,25 @@
       }
 
       async function joinEvent(eventId) {
+        const eventDateStr = eventData.event_date;
+        const startTime = eventData.start_time;
+        const endTime = eventData.end_time;
+
+        const today = new Date();
+        const selectedDate = new Date(`${eventDateStr}T00:00:00`);
+        selectedDate.setHours(0, 0, 0, 0);
+        const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+        if (selectedDate < todayStart) {
+          alert('このイベントはすでに終了しています');
+          return;
+        }
+
+        if (startTime >= endTime) {
+          alert('開始時間と終了時間が不正です');
+          return;
+        }
+
         const { error } = await supabase.from('event_participants').insert({
           event_id: eventId,
           user_id: currentUser.id,

--- a/events.html
+++ b/events.html
@@ -1032,6 +1032,25 @@
 
       // イベント作成
       async function createEvent(formData) {
+        const eventDateStr = formData.get("event-date");
+        const startTime = formData.get("event-start-time");
+        const endTime = formData.get("event-end-time");
+
+        const today = new Date();
+        const selectedDate = new Date(`${eventDateStr}T00:00:00`);
+        selectedDate.setHours(0, 0, 0, 0);
+        const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+        if (selectedDate < todayStart) {
+          alert("開催日は今日以降の日付を選択してください。");
+          throw new Error("Invalid event date");
+        }
+
+        if (startTime >= endTime) {
+          alert("開始時間は終了時間より前である必要があります。");
+          throw new Error("Invalid event time");
+        }
+
         const eventData = {
           title: formData.get("event-title"),
           description: formData.get("event-description"),
@@ -1077,6 +1096,25 @@
 
       // イベント更新
       async function updateEvent(eventId, formData) {
+        const eventDateStr = formData.get("event-date");
+        const startTime = formData.get("event-start-time");
+        const endTime = formData.get("event-end-time");
+
+        const today = new Date();
+        const selectedDate = new Date(`${eventDateStr}T00:00:00`);
+        selectedDate.setHours(0, 0, 0, 0);
+        const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+        if (selectedDate < todayStart) {
+          alert("開催日は今日以降の日付を選択してください。");
+          throw new Error("Invalid event date");
+        }
+
+        if (startTime >= endTime) {
+          alert("開始時間は終了時間より前である必要があります。");
+          throw new Error("Invalid event time");
+        }
+
         const updateData = {
           title: formData.get("event-title"),
           description: formData.get("event-description"),


### PR DESCRIPTION
## Summary
- ensure event start/end times and dates are valid when creating or updating
- block joining events in event-detail page if event date/time is invalid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f19000848330835bec7ef0ec2f79