### PR TITLE
Check event status before joining

### DIFF
--- a/event-detail.html
+++ b/event-detail.html
@@ -174,6 +174,33 @@
       }
 
       async function joinEvent(eventId) {
+        const { data: event, error: fetchError } = await supabase
+          .from('events')
+          .select('status, max_attendees, event_participants(count)')
+          .eq('id', eventId)
+          .single();
+
+        if (fetchError || !event) {
+          alert('イベント情報の取得に失敗しました');
+          return;
+        }
+
+        const participantCount = event.event_participants?.[0]?.count || 0;
+        const remainingSeats =
+          event.max_attendees !== null
+            ? event.max_attendees - participantCount
+            : Infinity;
+
+        if (event.status === 'canceled') {
+          alert('このイベントは中止されています');
+          return;
+        }
+
+        if (event.max_attendees !== null && remainingSeats <= 0) {
+          alert('イベントは満席です');
+          return;
+        }
+
         const { error } = await supabase.from('event_participants').insert({
           event_id: eventId,
           user_id: currentUser.id,

--- a/events.html
+++ b/events.html
@@ -980,6 +980,34 @@
 
       // イベント参加
       async function joinEvent(eventId) {
+        const { data: event, error: fetchError } = await supabase
+          .from("events")
+          .select("status, max_attendees, event_participants(count)")
+          .eq("id", eventId)
+          .single();
+
+        if (fetchError || !event) {
+          console.error("Error fetching event:", fetchError);
+          alert("イベント情報の取得に失敗しました");
+          return;
+        }
+
+        const participantCount = event.event_participants?.[0]?.count || 0;
+        const remainingSeats =
+          event.max_attendees !== null
+            ? event.max_attendees - participantCount
+            : Infinity;
+
+        if (event.status === "canceled") {
+          alert("このイベントは中止されています");
+          return;
+        }
+
+        if (event.max_attendees !== null && remainingSeats <= 0) {
+          alert("イベントは満席です");
+          return;
+        }
+
         const { error } = await supabase.from("event_participants").insert({
           event_id: eventId,
           user_id: currentUser.id,

--- a/notifications.html
+++ b/notifications.html
@@ -1052,6 +1052,33 @@
       }
 
       async function participateEvent(eventId) {
+        const { data: event, error: fetchError } = await supabase
+          .from("events")
+          .select("status, max_attendees, event_participants(count)")
+          .eq("id", eventId)
+          .single();
+
+        if (fetchError || !event) {
+          alert("イベント情報の取得に失敗しました");
+          return;
+        }
+
+        const participantCount = event.event_participants?.[0]?.count || 0;
+        const remainingSeats =
+          event.max_attendees !== null
+            ? event.max_attendees - participantCount
+            : Infinity;
+
+        if (event.status === "canceled") {
+          alert("このイベントは中止されています");
+          return;
+        }
+
+        if (event.max_attendees !== null && remainingSeats <= 0) {
+          alert("イベントは満席です");
+          return;
+        }
+
         const { error } = await supabase.from("event_participants").insert({
           event_id: eventId,
           user_id: currentUser.id,
@@ -1064,6 +1091,33 @@
       }
 
       async function declineEvent(eventId) {
+        const { data: event, error: fetchError } = await supabase
+          .from("events")
+          .select("status, max_attendees, event_participants(count)")
+          .eq("id", eventId)
+          .single();
+
+        if (fetchError || !event) {
+          alert("イベント情報の取得に失敗しました");
+          return;
+        }
+
+        const participantCount = event.event_participants?.[0]?.count || 0;
+        const remainingSeats =
+          event.max_attendees !== null
+            ? event.max_attendees - participantCount
+            : Infinity;
+
+        if (event.status === "canceled") {
+          alert("このイベントは中止されています");
+          return;
+        }
+
+        if (event.max_attendees !== null && remainingSeats <= 0) {
+          alert("イベントは満席です");
+          return;
+        }
+
         const { error } = await supabase.from("event_participants").insert({
           event_id: eventId,
           user_id: currentUser.id,


### PR DESCRIPTION
## Summary
- validate event status and remaining seats before adding to `event_participants`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f191720483308261e9dbd3255fa5