### PR TITLE
Add keyword search to event filters

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -2,11 +2,11 @@ import { jest } from '@jest/globals';
 import { filterEvents } from '../js/events.js';
 
 const events = [
-  { id: 1, event_type: 'conference', format: 'in-person', location: 'Tokyo', event_date: '2024-05-15' },
-  { id: 2, event_type: 'meetup', format: 'online', location: 'Zoom', event_date: '2024-05-16' },
-  { id: 3, event_type: 'workshop', format: 'in-person', location: 'Osaka', event_date: '2024-05-25' },
-  { id: 4, event_type: 'hackathon', format: 'in-person', location: 'Nagoya', event_date: '2024-06-10' },
-  { id: 5, event_type: 'meetup', format: 'online', location: null, event_date: '2024-06-20' },
+  { id: 1, title: 'Tech Conference', description: 'Annual tech event', event_type: 'conference', format: 'in-person', location: 'Tokyo', event_date: '2024-05-15' },
+  { id: 2, title: 'Online Meetup', description: 'Discuss projects', event_type: 'meetup', format: 'online', location: 'Zoom', event_date: '2024-05-16' },
+  { id: 3, title: 'Workshop', description: 'Hands-on coding', event_type: 'workshop', format: 'in-person', location: 'Osaka', event_date: '2024-05-25' },
+  { id: 4, title: 'Hack Nagoya', description: 'Hackathon event', event_type: 'hackathon', format: 'in-person', location: 'Nagoya', event_date: '2024-06-10' },
+  { id: 5, title: 'Another Meetup', description: 'Meetup about testing', event_type: 'meetup', format: 'online', location: null, event_date: '2024-06-20' },
 ];
 
 beforeAll(() => {
@@ -55,5 +55,15 @@ test('filters by next month', () => {
 
 test('filters by combined criteria', () => {
   const result = filterEvents(events, { type: 'meetup', location: 'online', date: 'this-week' });
+  expect(result).toEqual([events[1]]);
+});
+
+test('filters by keyword in title', () => {
+  const result = filterEvents(events, { keyword: 'hack' });
+  expect(result).toEqual([events[3]]);
+});
+
+test('filters by keyword in description case-insensitively', () => {
+  const result = filterEvents(events, { keyword: 'projects' });
   expect(result).toEqual([events[1]]);
 });

--- a/events.html
+++ b/events.html
@@ -70,7 +70,7 @@
 
       <!-- フィルターセクション -->
       <div class="bg-white rounded-lg shadow-sm p-4 mb-6">
-        <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-5 gap-4">
           <div>
             <label
               for="event-type"
@@ -123,6 +123,15 @@
               <option value="this-month">今月</option>
               <option value="next-month">来月</option>
             </select>
+          </div>
+          <div>
+            <label for="event-keyword" class="block text-sm font-medium text-gray-700 mb-1">キーワード</label>
+            <input
+              type="text"
+              id="event-keyword"
+              class="w-full border border-gray-300 rounded-md py-2 px-3 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="タイトルや説明で検索"
+            />
           </div>
           <div class="flex items-end">
             <button
@@ -1229,11 +1238,13 @@
         const typeFilter = document.getElementById("event-type").value;
         const locationFilter = document.getElementById("event-location-filter").value;
         const dateFilter = document.getElementById("event-date-filter").value;
+        const keywordFilter = document.getElementById("event-keyword").value.trim();
 
         const filteredEvents = applyFilterEvents(allEvents, {
           type: typeFilter,
           location: locationFilter,
           date: dateFilter,
+          keyword: keywordFilter,
         });
 
         displayEvents(filteredEvents);
@@ -1452,9 +1463,10 @@
         .addEventListener("click", filterEvents);
 
       // フィルター変更時の自動検索
-      ["event-type", "event-location-filter", "event-date-filter"].forEach(
+      ["event-type", "event-location-filter", "event-date-filter", "event-keyword"].forEach(
         (id) => {
-          document.getElementById(id).addEventListener("change", filterEvents);
+          const eventType = id === "event-keyword" ? "input" : "change";
+          document.getElementById(id).addEventListener(eventType, filterEvents);
         }
       );
 

--- a/js/events.js
+++ b/js/events.js
@@ -1,4 +1,4 @@
-export function filterEvents(allEvents, { type = '', location = '', date = '' } = {}) {
+export function filterEvents(allEvents, { type = '', location = '', date = '', keyword = '' } = {}) {
   let filtered = allEvents;
 
   if (type) {
@@ -42,6 +42,14 @@ export function filterEvents(allEvents, { type = '', location = '', date = '' } 
           return true;
       }
     });
+  }
+
+  if (keyword) {
+    const kw = keyword.toLowerCase();
+    filtered = filtered.filter(event => (
+      (event.title && event.title.toLowerCase().includes(kw)) ||
+      (event.description && event.description.toLowerCase().includes(kw))
+    ));
   }
 
   return filtered;


### PR DESCRIPTION
## Summary
- add keyword text input for event filters
- support keyword search in `filterEvents`
- wire up new input in the events page
- test event keyword filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f191f27483309d6a74491131fea2