### PR TITLE
Add calendar export for events

### DIFF
--- a/event-detail.html
+++ b/event-detail.html
@@ -154,7 +154,8 @@
             <h2 class="font-semibold mb-2">参加者 (${participants.length})</h2>
             <div class="flex -space-x-2">${participantAvatars}</div>
           </div>
-          <div id="action-area"></div>
+          <div id="action-area" class="mb-4"></div>
+          <button id="add-calendar-btn" class="px-4 py-2 border border-blue-600 text-blue-600 rounded-lg">カレンダーに追加</button>
         `;
 
         const actionArea = document.getElementById('action-area');
@@ -170,6 +171,10 @@
               document.getElementById('join-btn').addEventListener('click', () => joinEvent(eventData.id));
             }
           }
+        }
+        const calBtn = document.getElementById('add-calendar-btn');
+        if (calBtn && window.downloadICS) {
+          calBtn.addEventListener('click', () => window.downloadICS(eventData));
         }
       }
 
@@ -233,6 +238,10 @@
         await supabase.auth.signOut();
         window.location.href = 'login.html?message=logout';
       });
+    </script>
+    <script type="module">
+      import { downloadICS } from './js/ics.js';
+      window.downloadICS = downloadICS;
     </script>
   </body>
 </html>

--- a/js/ics.js
+++ b/js/ics.js
@@ -1,0 +1,49 @@
+export function generateICS(event) {
+  const pad = (num) => String(num).padStart(2, '0');
+  const toICSDate = (date) => {
+    return (
+      date.getUTCFullYear() +
+      pad(date.getUTCMonth() + 1) +
+      pad(date.getUTCDate()) +
+      'T' +
+      pad(date.getUTCHours()) +
+      pad(date.getUTCMinutes()) +
+      pad(date.getUTCSeconds()) +
+      'Z'
+    );
+  };
+
+  const start = new Date(`${event.event_date}T${event.start_time}`);
+  const end = new Date(`${event.event_date}T${event.end_time}`);
+  const location = event.format === 'online' ? 'オンライン' : (event.location || '');
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//startup-connect//EN',
+    'BEGIN:VEVENT',
+    `UID:${event.id || Date.now()}@startup-connect`,
+    `DTSTAMP:${toICSDate(new Date())}`,
+    `DTSTART:${toICSDate(start)}`,
+    `DTEND:${toICSDate(end)}`,
+    `SUMMARY:${event.title}`,
+    `LOCATION:${location}`,
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ];
+
+  return lines.join('\r\n');
+}
+
+export function downloadICS(event) {
+  const icsContent = generateICS(event);
+  const blob = new Blob([icsContent], { type: 'text/calendar' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${event.title || 'event'}.ics`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- enable generating iCalendar files
- show "Add to Calendar" button on event detail page

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850f1933280833085656df11632b740