### PR TITLE
Add My Events filter

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -2,11 +2,11 @@ import { jest } from '@jest/globals';
 import { filterEvents } from '../js/events.js';
 
 const events = [
-  { id: 1, event_type: 'conference', format: 'in-person', location: 'Tokyo', event_date: '2024-05-15' },
-  { id: 2, event_type: 'meetup', format: 'online', location: 'Zoom', event_date: '2024-05-16' },
-  { id: 3, event_type: 'workshop', format: 'in-person', location: 'Osaka', event_date: '2024-05-25' },
-  { id: 4, event_type: 'hackathon', format: 'in-person', location: 'Nagoya', event_date: '2024-06-10' },
-  { id: 5, event_type: 'meetup', format: 'online', location: null, event_date: '2024-06-20' },
+  { id: 1, organizer_id: 'user1', event_type: 'conference', format: 'in-person', location: 'Tokyo', event_date: '2024-05-15' },
+  { id: 2, organizer_id: 'user2', event_type: 'meetup', format: 'online', location: 'Zoom', event_date: '2024-05-16' },
+  { id: 3, organizer_id: 'user3', event_type: 'workshop', format: 'in-person', location: 'Osaka', event_date: '2024-05-25' },
+  { id: 4, organizer_id: 'user2', event_type: 'hackathon', format: 'in-person', location: 'Nagoya', event_date: '2024-06-10' },
+  { id: 5, organizer_id: 'user1', event_type: 'meetup', format: 'online', location: null, event_date: '2024-06-20' },
 ];
 
 beforeAll(() => {
@@ -56,4 +56,13 @@ test('filters by next month', () => {
 test('filters by combined criteria', () => {
   const result = filterEvents(events, { type: 'meetup', location: 'online', date: 'this-week' });
   expect(result).toEqual([events[1]]);
+});
+
+test('filters by my events', () => {
+  const result = filterEvents(events, {
+    myEvents: true,
+    userId: 'user1',
+    participatingIds: new Set([2]),
+  });
+  expect(result).toEqual([events[0], events[1], events[4]]);
 });

--- a/events.html
+++ b/events.html
@@ -70,7 +70,7 @@
 
       <!-- フィルターセクション -->
       <div class="bg-white rounded-lg shadow-sm p-4 mb-6">
-        <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-5 gap-4">
           <div>
             <label
               for="event-type"
@@ -131,6 +131,16 @@
             >
               検索
             </button>
+          </div>
+          <div class="flex items-end">
+            <label class="inline-flex items-center">
+              <input
+                type="checkbox"
+                id="my-events-toggle"
+                class="h-4 w-4 text-blue-600 border-gray-300 rounded"
+              />
+              <span class="ml-2 text-sm text-gray-700">My Events</span>
+            </label>
           </div>
         </div>
       </div>
@@ -713,8 +723,8 @@
       // ページ読み込み時の初期化
       window.addEventListener("load", async () => {
         await checkAuth();
-        await loadEvents();
         await loadParticipatingEvents();
+        await loadEvents();
         setupRealtimeSubscriptions();
       });
 
@@ -780,7 +790,7 @@
         }
 
         allEvents = events || [];
-        displayEvents(allEvents);
+        filterEvents();
         hideLoading();
       }
 
@@ -793,6 +803,7 @@
 
         if (participations) {
           participatingEvents = new Set(participations.map((p) => p.event_id));
+          filterEvents();
         }
       }
 
@@ -1229,11 +1240,15 @@
         const typeFilter = document.getElementById("event-type").value;
         const locationFilter = document.getElementById("event-location-filter").value;
         const dateFilter = document.getElementById("event-date-filter").value;
+        const myEventsOnly = document.getElementById("my-events-toggle").checked;
 
         const filteredEvents = applyFilterEvents(allEvents, {
           type: typeFilter,
           location: locationFilter,
           date: dateFilter,
+          myEvents: myEventsOnly,
+          userId: currentUser.id,
+          participatingIds: participatingEvents,
         });
 
         displayEvents(filteredEvents);
@@ -1452,7 +1467,7 @@
         .addEventListener("click", filterEvents);
 
       // フィルター変更時の自動検索
-      ["event-type", "event-location-filter", "event-date-filter"].forEach(
+      ["event-type", "event-location-filter", "event-date-filter", "my-events-toggle"].forEach(
         (id) => {
           document.getElementById(id).addEventListener("change", filterEvents);
         }

--- a/js/events.js
+++ b/js/events.js
@@ -1,4 +1,14 @@
-export function filterEvents(allEvents, { type = '', location = '', date = '' } = {}) {
+export function filterEvents(
+  allEvents,
+  {
+    type = '',
+    location = '',
+    date = '',
+    myEvents = false,
+    userId = null,
+    participatingIds = new Set(),
+  } = {}
+) {
   let filtered = allEvents;
 
   if (type) {
@@ -42,6 +52,12 @@ export function filterEvents(allEvents, { type = '', location = '', date = '' } 
           return true;
       }
     });
+  }
+
+  if (myEvents && userId) {
+    filtered = filtered.filter(
+      (event) => event.organizer_id === userId || participatingIds.has(event.id)
+    );
   }
 
   return filtered;


### PR DESCRIPTION
## Summary
- expand event filtering function with `myEvents` option
- add My Events toggle in event filter UI
- rework event loading to respect toggle state
- update filtering tests for new option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f1963a5883309881b2ce7a46f230