### PR TITLE
Handle extra notification types

### DIFF
--- a/notifications.html
+++ b/notifications.html
@@ -399,8 +399,11 @@
           if (notification.related_id) {
             switch (notification.type) {
               case "follow":
+              case "follow_request":
+              case "follow_request_accepted":
               case "message":
               case "mention":
+              case "report":
                 userIds.add(notification.related_id);
                 break;
               case "group_invite":
@@ -409,6 +412,9 @@
                 break;
               case "event":
               case "event_reminder":
+              case "event_join":
+              case "event_update":
+              case "event_cancel":
                 eventIds.add(notification.related_id);
                 break;
             }
@@ -615,6 +621,23 @@
               : "";
             break;
 
+          case "follow_request_accepted":
+            const approver = relatedUsers.get(notification.related_id);
+            icon = approver
+              ? `<img loading="lazy" class="h-12 w-12 rounded-full object-cover" src="${
+                  approver.profile_image_url || "/api/placeholder/48/48"
+                }" alt="${approver.last_name} ${approver.first_name}">`
+              : `<div class="h-12 w-12 rounded-full bg-blue-100 flex items-center justify-center">
+                            <svg class="h-6 w-6 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                            </svg>
+                        </div>`;
+            content = notification.content;
+            actions = approver
+              ? `<a href="profile-detail.html?user=${notification.related_id}" class="text-blue-600 hover:text-blue-800 text-xs font-medium">プロフィールを見る</a>`
+              : "";
+            break;
+
           case "message":
             const sender = relatedUsers.get(notification.related_id);
             icon = sender
@@ -654,6 +677,22 @@
             }
             break;
 
+          case "event_join":
+          case "event_update":
+          case "event_cancel":
+            const eventInfo = relatedEvents.get(notification.related_id);
+            const isCancel = notification.type === "event_cancel";
+            icon = `<div class="h-12 w-12 rounded-full ${isCancel ? 'bg-red-100' : 'bg-purple-100'} flex items-center justify-center">
+                        <svg class="h-6 w-6 ${isCancel ? 'text-red-600' : 'text-purple-600'}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                    </div>`;
+            content = notification.content;
+            actions = eventInfo
+              ? `<a href="events.html?id=${notification.related_id}" class="text-blue-600 hover:text-blue-800 text-xs font-medium">イベント詳細を見る</a>`
+              : "";
+            break;
+
           case "group_invite":
             const group = relatedGroups.get(notification.related_id);
             icon = `<div class="h-12 w-12 rounded-full bg-green-100 flex items-center justify-center">
@@ -668,6 +707,19 @@
                         <a href="groups.html?id=${notification.related_id}" class="border border-gray-300 text-gray-700 py-1 px-3 rounded-md text-xs font-medium hover:bg-gray-50 transition duration-200">詳細を見る</a>
                         <button onclick="declineGroup('${notification.related_id}')" class="border border-gray-300 text-gray-700 py-1 px-3 rounded-md text-xs font-medium hover:bg-gray-50 transition duration-200">辞退する</button>
                     `
+              : "";
+            break;
+
+          case "group_activity":
+            const activityGroup = relatedGroups.get(notification.related_id);
+            icon = `<div class="h-12 w-12 rounded-full bg-green-100 flex items-center justify-center">
+                        <svg class="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                        </svg>
+                    </div>`;
+            content = notification.content;
+            actions = activityGroup
+              ? `<a href="groups.html?id=${notification.related_id}" class="text-blue-600 hover:text-blue-800 text-xs font-medium">グループを見る</a>`
               : "";
             break;
 
@@ -694,6 +746,23 @@
                     </div>`;
             content = notification.content;
             actions = `<a href="#" class="text-blue-600 hover:text-blue-800 text-xs font-medium">投稿を見る</a>`;
+            break;
+
+          case "report":
+            const reporter = relatedUsers.get(notification.related_id);
+            icon = reporter
+              ? `<img loading="lazy" class="h-12 w-12 rounded-full object-cover" src="${
+                  reporter.profile_image_url || "/api/placeholder/48/48"
+                }" alt="${reporter.last_name} ${reporter.first_name}">`
+              : `<div class="h-12 w-12 rounded-full bg-red-100 flex items-center justify-center">
+                            <svg class="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                            </svg>
+                        </div>`;
+            content = notification.content;
+            actions = reporter
+              ? `<a href="profile-detail.html?user=${notification.related_id}" class="text-blue-600 hover:text-blue-800 text-xs font-medium">プロフィールを見る</a>`
+              : "";
             break;
 
           default:


### PR DESCRIPTION
## Summary
- include ids for new notification types when loading related entities
- show details for follow request acceptance, updated events, group activity and reports
- provide event update/cancel/join actions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f1dc08a483308c417b323bf61696