### PR TITLE
Handle declining group invites

### DIFF
--- a/notifications.html
+++ b/notifications.html
@@ -1088,7 +1088,40 @@
       }
 
       async function declineGroup(groupId) {
-        alert("グループへの参加を辞退しました。");
+        const notification = notifications.find(
+          (n) => n.type === "group_invite" && n.related_id === groupId
+        );
+        const notificationElement = notification
+          ? document.querySelector(`[data-notification-id="${notification.id}"]`)
+          : null;
+        if (notificationElement) {
+          notificationElement.classList.add("fade-out");
+        }
+
+        const { error } = await supabase
+          .from("notifications")
+          .delete()
+          .eq("user_id", currentUser.id)
+          .eq("type", "group_invite")
+          .eq("related_id", groupId);
+
+        if (error) {
+          console.error("Error declining group invite:", error);
+          if (notificationElement) {
+            notificationElement.classList.remove("fade-out");
+          }
+          return;
+        }
+
+        // TODO: Optionally notify the inviter about the decline if inviter info is available
+
+        setTimeout(() => {
+          notifications = notifications.filter(
+            (n) => !(n.type === "group_invite" && n.related_id === groupId)
+          );
+          applyFilter();
+          updateUnreadBadges();
+        }, 300);
       }
 
       // イベントリスナー設定


### PR DESCRIPTION
## Summary
- clean up group invite notifications when declining

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f1dd40408330b16f994b9aa5b0d7