### PR TITLE
Clean up unused iconColor variable

### DIFF
--- a/notifications.html
+++ b/notifications.html
@@ -518,7 +518,7 @@
       // 通知HTML作成
       function createNotificationHTML(notification) {
         const isUnread = !notification.is_read;
-        const { icon, iconColor, content, actions } =
+        const { icon, content, actions } =
           getNotificationDetails(notification);
 
         return `
@@ -571,7 +571,7 @@
 
       // 通知詳細取得
       function getNotificationDetails(notification) {
-        let icon, iconColor, content, actions;
+        let icon, content, actions;
 
         switch (notification.type) {
           case "follow":
@@ -706,7 +706,7 @@
             actions = "";
         }
 
-        return { icon, iconColor, content, actions };
+        return { icon, content, actions };
       }
 
       // すべて既読にする


### PR DESCRIPTION
## Summary
- remove the unused `iconColor` variable when building notification entries
- adjust helper return object accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f1de0bbc8330bc98a8eb084fd5c0