### PR TITLE
Add message reactions and stickers

### DIFF
--- a/SQL_SCHEMA.md
+++ b/SQL_SCHEMA.md
@@ -112,7 +112,18 @@ CREATE INDEX idx_group_messages_group   ON public.group_messages(group_id);
 CREATE INDEX idx_group_messages_created ON public.group_messages(created_at DESC);
 CREATE INDEX idx_group_messages_user    ON public.group_messages(user_id);
 
--- 4-4) Group Members
+-- 4-4) Group Message Reactions
+CREATE TABLE public.group_message_reactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id uuid REFERENCES public.group_messages(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reaction text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX idx_gm_reactions_message ON public.group_message_reactions(message_id);
+CREATE INDEX idx_gm_reactions_user ON public.group_message_reactions(user_id);
+
+-- 4-5) Group Members
 CREATE TABLE public.group_members (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   group_id uuid NOT NULL REFERENCES public.groups(id) ON DELETE CASCADE,
@@ -124,7 +135,7 @@ CREATE TABLE public.group_members (
 CREATE INDEX idx_group_members_group ON public.group_members(group_id);
 CREATE INDEX idx_group_members_user  ON public.group_members(user_id);
 
--- 4-5) Follows
+-- 4-6) Follows
 CREATE TABLE public.follows (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   follower_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -135,7 +146,7 @@ CREATE TABLE public.follows (
 CREATE INDEX idx_follows_follower  ON public.follows(follower_id);
 CREATE INDEX idx_follows_following ON public.follows(following_id);
 
--- 4-6) Follow Requests
+-- 4-7) Follow Requests
 CREATE TABLE public.follow_requests (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   requester_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -147,7 +158,7 @@ CREATE TABLE public.follow_requests (
 CREATE INDEX idx_follow_requests_requester ON public.follow_requests(requester_id);
 CREATE INDEX idx_follow_requests_target   ON public.follow_requests(target_id);
 
--- 4-7) Events
+-- 4-8) Events
 CREATE TABLE public.events (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   title text NOT NULL,
@@ -173,7 +184,7 @@ CREATE TRIGGER handle_events_updated_at
   BEFORE UPDATE ON public.events
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-8) Event Participants
+-- 4-9) Event Participants
 CREATE TABLE public.event_participants (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   event_id uuid REFERENCES public.events(id) ON DELETE CASCADE,
@@ -185,7 +196,7 @@ CREATE TABLE public.event_participants (
 CREATE INDEX idx_event_participants_event ON public.event_participants(event_id);
 CREATE INDEX idx_event_participants_user  ON public.event_participants(user_id);
 
--- 4-9) Blocked Users
+-- 4-10) Blocked Users
 CREATE TABLE public.blocked_users (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   blocker_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -196,7 +207,7 @@ CREATE TABLE public.blocked_users (
 CREATE INDEX idx_blocked_users_blocker_id ON public.blocked_users(blocker_id);
 CREATE INDEX idx_blocked_users_blocked_id ON public.blocked_users(blocked_id);
 
--- 4-10) Direct Messages
+-- 4-11) Direct Messages
 CREATE TABLE public.direct_messages (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   sender_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
@@ -210,7 +221,18 @@ CREATE INDEX idx_direct_messages_sender   ON public.direct_messages(sender_id);
 CREATE INDEX idx_direct_messages_receiver ON public.direct_messages(receiver_id);
 CREATE INDEX idx_direct_messages_created  ON public.direct_messages(created_at DESC);
 
--- 4-11) Projects
+-- 4-12) Direct Message Reactions
+CREATE TABLE public.direct_message_reactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id uuid REFERENCES public.direct_messages(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reaction text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX idx_dm_reactions_message ON public.direct_message_reactions(message_id);
+CREATE INDEX idx_dm_reactions_user ON public.direct_message_reactions(user_id);
+
+-- 4-13) Projects
 CREATE TABLE public.projects (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -230,7 +252,7 @@ CREATE TRIGGER handle_projects_updated_at
   BEFORE UPDATE ON public.projects
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-12) Privacy Settings
+-- 4-14) Privacy Settings
 CREATE TABLE public.privacy_settings (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -250,7 +272,7 @@ CREATE TRIGGER update_privacy_settings_updated_at
   BEFORE UPDATE ON public.privacy_settings
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
--- 4-13) Posts
+-- 4-15) Posts
 CREATE TABLE public.posts (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -267,7 +289,7 @@ CREATE TRIGGER handle_posts_updated_at
   BEFORE UPDATE ON public.posts
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-14) Post Likes
+-- 4-16) Post Likes
 CREATE TABLE public.post_likes (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -278,7 +300,7 @@ CREATE TABLE public.post_likes (
 CREATE INDEX idx_post_likes_user_id ON public.post_likes(user_id);
 CREATE INDEX idx_post_likes_post_id ON public.post_likes(post_id);
 
--- 4-15) Post Comments
+-- 4-17) Post Comments
 CREATE TABLE public.post_comments (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -293,7 +315,7 @@ CREATE TRIGGER handle_post_comments_updated_at
   BEFORE UPDATE ON public.post_comments
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-16) Post Bookmarks
+-- 4-18) Post Bookmarks
 CREATE TABLE public.post_bookmarks (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -304,7 +326,7 @@ CREATE TABLE public.post_bookmarks (
 CREATE INDEX idx_post_bookmarks_user ON public.post_bookmarks(user_id);
 CREATE INDEX idx_post_bookmarks_post ON public.post_bookmarks(post_id);
 
--- 4-17) Notifications
+-- 4-19) Notifications
 CREATE TABLE public.notifications (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -318,7 +340,7 @@ CREATE TABLE public.notifications (
 CREATE INDEX idx_notifications_user ON public.notifications(user_id);
 CREATE INDEX idx_notifications_read ON public.notifications(is_read);
 
--- 4-18) Notification Settings
+-- 4-20) Notification Settings
 CREATE TABLE public.notification_settings (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -337,7 +359,7 @@ CREATE TRIGGER update_notification_settings_updated_at
   BEFORE UPDATE ON public.notification_settings
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
--- 4-19) User Sessions
+-- 4-21) User Sessions
 CREATE TABLE public.user_sessions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -353,7 +375,7 @@ CREATE TABLE public.user_sessions (
 );
 CREATE INDEX idx_user_sessions_user_id ON public.user_sessions(user_id);
 
--- 4-20) Startup Info
+-- 4-22) Startup Info
 CREATE TABLE public.startup_info (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
@@ -370,7 +392,7 @@ CREATE TRIGGER handle_startup_info_updated_at
   BEFORE UPDATE ON public.startup_info
   FOR EACH ROW EXECUTE FUNCTION handle_updated_at();
 
--- 4-21) Shared Files
+-- 4-23) Shared Files
 CREATE TABLE public.shared_files (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   name text NOT NULL,
@@ -383,7 +405,7 @@ CREATE TABLE public.shared_files (
   created_at timestamptz DEFAULT now()
 );
 
--- 4-22) Security Settings
+-- 4-24) Security Settings
 CREATE TABLE public.security_settings (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -400,7 +422,7 @@ CREATE TRIGGER update_security_settings_updated_at
   BEFORE UPDATE ON public.security_settings
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
--- 4-23) Push Subscriptions
+-- 4-25) Push Subscriptions
 CREATE TABLE public.push_subscriptions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
@@ -411,7 +433,7 @@ CREATE TABLE public.push_subscriptions (
 );
 CREATE INDEX idx_push_subscriptions_user_id ON public.push_subscriptions(user_id);
 
--- 4-24) Profile Embeddings
+-- 4-26) Profile Embeddings
 CREATE TABLE public.profile_embeddings (
   user_id uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
   embedding vector(1536)

--- a/groups.html
+++ b/groups.html
@@ -321,7 +321,7 @@
 
               <!-- メッセージ入力エリア -->
               <div class="border-t border-gray-200 p-4">
-                <div class="flex items-center">
+                <div class="flex items-center relative">
                   <button
                     type="button"
                     id="attach-file-btn"
@@ -387,6 +387,11 @@
                       />
                     </svg>
                   </button>
+                  <button type="button" id="sticker-btn" class="p-2" title="スタンプ">
+                    <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197.106 1.043-3.137-1.778-2.057 2.39-.454L12 2l1.79 3.626 2.39.454-1.778 2.057 1.043 3.137z" />
+                    </svg>
+                  </button>
                   <input
                     type="file"
                     id="file-input"
@@ -399,6 +404,12 @@
                     class="hidden"
                     accept="image/*"
                   />
+                  <div id="sticker-panel" class="hidden absolute bottom-12 right-0 bg-white border rounded shadow p-2 flex gap-2">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABs0lEQVR4nO2bSw7DIAxEoer9r0xXVBFqhX/jIYpnVykJ44dNSeL0MdpoD9aLbYCtAsA2wFYBYBtgqwCwDbD1zh6w9/0xI3FnAgcgCXh3DhIIDMC/wCXBrOfO3wgQPXorjJg9ZEaEArgahcwW4PohANCBI8dz/w1mB7+OY1lkr3IBYAT/azwPBHMJIFdmrTxeTBngTTuULL5cJXDC7Lfm86EGcFLqXzX9aLNABeDU4KcsEB5/NygGcPrsT2mzoDJActBdZn9KkwWVAVkDaf+esjZbaQC05ZNVblsAd6v/Kek6UGsA2wBbBSD6gr3jVnDEtSsD2AbYKgDRF7Q+mNgJtR/ZAkAFhJYUGKQEoqEhd6PwNcALAZ15MAARLy4yXryIAFhT2gPBE7ymZOAlsELYgViPQd+Fql6NeRcjTRZ4x5Cen9ojJCml7OcO6pejJz8gsXhTrwGnboysExPWH8CUx4cJwInp35rNl6tHiNkhEjV+WH9AdjlEwXdvhBgQIjOv+gSrUxT01Vhkr7DmXK1gAL4DBKwLt+wWn1rNP+57gVWnbaLqsTjbAFsFgG2ArQLANsDWB6aCsmtqqLzHAAAAAElFTkSuQmCC" class="w-10 h-10 cursor-pointer sticker-option" alt="smile">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAA1klEQVR4nO3YwQ3CMBAFUYLoCfo/maqcBiLlYK8eaP8UkIxGG2udY8wxH415agFNAmgBTQJoAU0CaAFNAmgBTQJoAU0CaAFNAmgBTQJoAU0CaAHNq/oFn+O9/IwxvxtMrmk/AQmgBTQJoAU0CaAFNOV7wA7udomVPaH9BCSAFtAsnwE7dn1J+wlIAC2gaR/gLxah/BApJAG0gGb5DLj7Pn99UWo/AQmgBTQJoAU0CaAFNOV3gco9fgftJyABtIAmAbSAJgG0gCYBtIAmAbSAJgG0gKZ9gBPWSRKqiZB+sgAAAABJRU5ErkJggg==" class="w-10 h-10 cursor-pointer sticker-option" alt="thumbs">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABTUlEQVR4nO2ZOxKDQAxDk5yK+1d7K1LRMMPwWUmvQDqALT/bwC7fdYz182L9aAO0CoA2QKsAaAO0CoA2QIsHsCxoehbAVjwIgQOwLxqCwAA4KhaAkAdwVmQYQhbA1eKCEHIA7hYVgpAB8LSYAAQ/gNkizBC8AFTmjRB8ANSmTRA8AFwdM8TVA3A/uMTxtQBS729hHh2A9GesKJ8GAHWaE+SdBwCf52fzzwMYYzoEmZ+/EYKlAUBNgSCvbgLSEET5ugLSaKkpEObRT4Abgjh+V8AS1TUFhri+CVCbNUHtClijq7pmfLD6J2DWvPmt0hWIZHnaxcCHVW4C7hYT+qrsCkSzXe1q8GSZn4Cz4sLH6q4AkvWoy8DNEjcB+2Kha7WuAJp96zp4tc5PAPxfgQcAqwBoA7QKgDZAqwBoA7QKgDZAqwBoA7QKgDZA6/UA/qT6Rg7J0JKoAAAAAElFTkSuQmCC" class="w-10 h-10 cursor-pointer sticker-option" alt="heart">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABeUlEQVR4nO2ZXQ7CMAyDGeJQnIUDchZuNZ4moYnRPyffKuwnJLTEc5y1aZd1fa2XP8aVJkDDAtAEaFgAmgANC0AToMEL8Lyj6XkBYLACbNUHXWAH0ARocALsbQ+1gR2AZD2qNuACO4AmQCNfgJLNk9vADqAJ0MgVoNbeiW1gB6Rlaq1qkguW4r0APK9L8Hgd/lV2wI+Hp0CBf10LzCpCBe9yC+wxQ0s0FKz9I3h2NzTy61sFzipCB6/+ZfBsInTyGdsHnEWEAR7jGyFahMH87avAL2SuECLhtVvhLDcI8+hngWgRxPFjhqEoEQLiehwOiRr1MQyIawfQBGhYAHnE6M2QOL4dQBOgoRWgx549mxthG9xkkVrx+eLb77+5Hj+qOjBa6wSorV7pJWtFELklrwVaqpvYEjkt0GvthJaIF2D0JYJF0ByJfbNqBPGAPD4QkUec7EhsvAU2WxLH44LcGgdQdwOCvNp7gQnhaZAmQMMC0ARoWACaAI03YaJpAQBXP6kAAAAASUVORK5CYII=" class="w-10 h-10 cursor-pointer sticker-option" alt="star">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1109,9 +1120,10 @@
           const { data: messages, error } = await supabase
             .from("group_messages")
             .select(
-              `
+            `
               *,
-              user:profiles!group_messages_user_id_fkey(*)
+              user:profiles!group_messages_user_id_fkey(*),
+              reactions:group_message_reactions!group_message_reactions_message_id_fkey(*)
             `
             )
             .eq("group_id", groupId)
@@ -1202,6 +1214,10 @@
                       .join("")}
                     <p>${escapeHtml(message.content)}</p>
                   </div>
+                  <div class="flex items-center gap-1 mt-1">
+                    ${summarizeReactions(message.reactions)}
+                    ${reactionButtons(message.id, true)}
+                  </div>
                 </div>
                 <img loading="lazy"
                   src="${
@@ -1266,6 +1282,10 @@
                       )
                       .join("")}
                     <p class="text-gray-800">${escapeHtml(message.content)}</p>
+                  </div>
+                  <div class="flex items-center gap-1 mt-1">
+                    ${summarizeReactions(message.reactions)}
+                    ${reactionButtons(message.id, true)}
                   </div>
                 </div>
               </div>
@@ -1683,6 +1703,50 @@
         return div.innerHTML;
       }
 
+      function summarizeReactions(reactions) {
+        if (!reactions || reactions.length === 0) return "";
+        const counts = {};
+        reactions.forEach((r) => {
+          counts[r.reaction] = (counts[r.reaction] || 0) + 1;
+        });
+        return Object.entries(counts)
+          .map(
+            ([e, c]) => `<span class="text-sm mr-1">${e} ${c}</span>`
+          )
+          .join("");
+      }
+
+      function reactionButtons(id, isGroup = true) {
+        return `
+          <button class="text-sm" onclick="addReaction('${id}','👍',${isGroup})">👍</button>
+          <button class="text-sm" onclick="addReaction('${id}','❤️',${isGroup})">❤️</button>
+          <button class="text-sm" onclick="addReaction('${id}','😂',${isGroup})">😂</button>
+        `;
+      }
+
+      async function addReaction(id, emoji, isGroup = true) {
+        const table = isGroup
+          ? "group_message_reactions"
+          : "direct_message_reactions";
+        await supabase.from(table).insert({
+          message_id: id,
+          user_id: currentUser.id,
+          reaction: emoji,
+        });
+
+        const msg = (currentMessages || []).find((m) => m.id === id);
+        if (msg && msg.user_id !== currentUser.id) {
+          await supabase.from("notifications").insert({
+            user_id: msg.user_id,
+            type: "reaction",
+            title: "リアクション",
+            content: `${userProfile.last_name} ${userProfile.first_name}さんがあなたのメッセージにリアクションしました`,
+            related_id: id,
+          });
+        }
+        await loadGroupMessages(currentGroup.id);
+      }
+
       // イベントリスナー設定
       document
         .querySelector(".mobile-menu-button")
@@ -1825,6 +1889,19 @@
             this.value = "";
           }
         });
+
+      document
+        .getElementById("sticker-btn")
+        .addEventListener("click", function () {
+          document.getElementById("sticker-panel").classList.toggle("hidden");
+        });
+
+      document.querySelectorAll(".sticker-option").forEach((img) => {
+        img.addEventListener("click", () => {
+          document.getElementById("sticker-panel").classList.add("hidden");
+          sendMessage("", [img.src]);
+        });
+      });
 
       // グループ作成モーダル
       document

--- a/messages.html
+++ b/messages.html
@@ -402,7 +402,7 @@
 
               <!-- メッセージ入力エリア -->
               <div class="border-t border-gray-200 p-4">
-                <div class="flex items-center">
+                <div class="flex items-center relative">
                   <button
                     type="button"
                     id="attach-file-btn"
@@ -471,6 +471,11 @@
                       />
                     </svg>
                   </button>
+                  <button type="button" id="sticker-btn" class="p-2" title="スタンプ">
+                    <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197.106 1.043-3.137-1.778-2.057 2.39-.454L12 2l1.79 3.626 2.39.454-1.778 2.057 1.043 3.137z" />
+                    </svg>
+                  </button>
                   <input
                     type="file"
                     id="file-input"
@@ -483,6 +488,12 @@
                     class="hidden"
                     accept="image/*"
                   />
+                  <div id="sticker-panel" class="hidden absolute bottom-12 right-0 bg-white border rounded shadow p-2 flex gap-2">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABs0lEQVR4nO2bSw7DIAxEoer9r0xXVBFqhX/jIYpnVykJ44dNSeL0MdpoD9aLbYCtAsA2wFYBYBtgqwCwDbD1zh6w9/0xI3FnAgcgCXh3DhIIDMC/wCXBrOfO3wgQPXorjJg9ZEaEArgahcwW4PohANCBI8dz/w1mB7+OY1lkr3IBYAT/azwPBHMJIFdmrTxeTBngTTuULL5cJXDC7Lfm86EGcFLqXzX9aLNABeDU4KcsEB5/NygGcPrsT2mzoDJActBdZn9KkwWVAVkDaf+esjZbaQC05ZNVblsAd6v/Kek6UGsA2wBbBSD6gr3jVnDEtSsD2AbYKgDRF7Q+mNgJtR/ZAkAFhJYUGKQEoqEhd6PwNcALAZ15MAARLy4yXryIAFhT2gPBE7ymZOAlsELYgViPQd+Fql6NeRcjTRZ4x5Cen9ojJCml7OcO6pejJz8gsXhTrwGnboysExPWH8CUx4cJwInp35rNl6tHiNkhEjV+WH9AdjlEwXdvhBgQIjOv+gSrUxT01Vhkr7DmXK1gAL4DBKwLt+wWn1rNP+57gVWnbaLqsTjbAFsFgG2ArQLANsDWB6aCsmtqqLzHAAAAAElFTkSuQmCC" class="w-10 h-10 cursor-pointer sticker-option" alt="smile">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAA1klEQVR4nO3YwQ3CMBAFUYLoCfo/maqcBiLlYK8eaP8UkIxGG2udY8wxH415agFNAmgBTQJoAU0CaAFNAmgBTQJoAU0CaAFNAmgBTQJoAU0CaAHNq/oFn+O9/IwxvxtMrmk/AQmgBTQJoAU0CaAFNOV7wA7udomVPaH9BCSAFtAsnwE7dn1J+wlIAC2gaR/gLxah/BApJAG0gGb5DLj7Pn99UWo/AQmgBTQJoAU0CaAFNOV3gco9fgftJyABtIAmAbSAJgG0gCYBtIAmAbSAJgG0gKZ9gBPWSRKqiZB+sgAAAABJRU5ErkJggg==" class="w-10 h-10 cursor-pointer sticker-option" alt="thumbs">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABTUlEQVR4nO2ZOxKDQAxDk5yK+1d7K1LRMMPwWUmvQDqALT/bwC7fdYz182L9aAO0CoA2QKsAaAO0CoA2QIsHsCxoehbAVjwIgQOwLxqCwAA4KhaAkAdwVmQYQhbA1eKCEHIA7hYVgpAB8LSYAAQ/gNkizBC8AFTmjRB8ANSmTRA8AFwdM8TVA3A/uMTxtQBS729hHh2A9GesKJ8GAHWaE+SdBwCf52fzzwMYYzoEmZ+/EYKlAUBNgSCvbgLSEET5ugLSaKkpEObRT4Abgjh+V8AS1TUFhri+CVCbNUHtClijq7pmfLD6J2DWvPmt0hWIZHnaxcCHVW4C7hYT+qrsCkSzXe1q8GSZn4Cz4sLH6q4AkvWoy8DNEjcB+2Kha7WuAJp96zp4tc5PAPxfgQcAqwBoA7QKgDZAqwBoA7QKgDZAqwBoA7QKgDZA6/UA/qT6Rg7J0JKoAAAAAElFTkSuQmCC" class="w-10 h-10 cursor-pointer sticker-option" alt="heart">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABeUlEQVR4nO2ZXQ7CMAyDGeJQnIUDchZuNZ4moYnRPyffKuwnJLTEc5y1aZd1fa2XP8aVJkDDAtAEaFgAmgANC0AToMEL8Lyj6XkBYLACbNUHXWAH0ARocALsbQ+1gR2AZD2qNuACO4AmQCNfgJLNk9vADqAJ0MgVoNbeiW1gB6Rlaq1qkguW4r0APK9L8Hgd/lV2wI+Hp0CBf10LzCpCBe9yC+wxQ0s0FKz9I3h2NzTy61sFzipCB6/+ZfBsInTyGdsHnEWEAR7jGyFahMH87avAL2SuECLhtVvhLDcI8+hngWgRxPFjhqEoEQLiehwOiRr1MQyIawfQBGhYAHnE6M2QOL4dQBOgoRWgx549mxthG9xkkVrx+eLb77+5Hj+qOjBa6wSorV7pJWtFELklrwVaqpvYEjkt0GvthJaIF2D0JYJF0ByJfbNqBPGAPD4QkUec7EhsvAU2WxLH44LcGgdQdwOCvNp7gQnhaZAmQMMC0ARoWACaAI03YaJpAQBXP6kAAAAASUVORK5CYII=" class="w-10 h-10 cursor-pointer sticker-option" alt="star">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1035,7 +1046,8 @@
             `
                     *,
                     sender:profiles!direct_messages_sender_id_fkey(*),
-                    receiver:profiles!direct_messages_receiver_id_fkey(*)
+                    receiver:profiles!direct_messages_receiver_id_fkey(*),
+                    reactions:direct_message_reactions!direct_message_reactions_message_id_fkey(*)
                 `
           )
           .or(
@@ -1107,15 +1119,17 @@
                                 <div class="bg-blue-600 text-white rounded-lg p-3 mt-1">
                                     ${
                                       typeof message.file_url === "string" &&
-                                      message.file_url.match(
-                                        /\.(jpg|jpeg|png|gif)$/i
-                                      )
+                                      message.file_url.match(/\.(jpg|jpeg|png|gif)$/i)
                                         ? `<img loading="lazy" src="${message.file_url}" class="max-w-full rounded">`
                                         : typeof message.file_url === "string"
                                         ? `<a href="${message.file_url}" target="_blank" class="text-blue-200 underline">📎 ファイルを開く</a>`
                                         : ``
                                     }
                                     <p>${escapeHtml(message.content)}</p>
+                                </div>
+                                <div class="flex items-center justify-end gap-1 mt-1">
+                                    ${summarizeReactions(message.reactions)}
+                                    ${reactionButtons(message.id)}
                                 </div>
                                 <div class="flex justify-end mt-1">
                                     <span class="text-xs text-gray-500">${
@@ -1178,6 +1192,10 @@
                                     <p class="text-gray-800">${
                                       escapeHtml(message.content)
                                     }</p>
+                                </div>
+                                <div class="flex items-center gap-1 mt-1">
+                                    ${summarizeReactions(message.reactions)}
+                                    ${reactionButtons(message.id)}
                                 </div>
                             </div>
                         </div>
@@ -1455,6 +1473,59 @@
         return div.innerHTML;
       }
 
+      function summarizeReactions(reactions) {
+        if (!reactions || reactions.length === 0) return "";
+        const counts = {};
+        reactions.forEach((r) => {
+          counts[r.reaction] = (counts[r.reaction] || 0) + 1;
+        });
+        return Object.entries(counts)
+          .map(
+            ([emoji, cnt]) =>
+              `<span class="text-sm mr-1">${emoji} ${cnt}</span>`
+          )
+          .join("");
+      }
+
+      function reactionButtons(id, isGroup = false) {
+        return `
+          <button class="text-sm" onclick="addReaction('${id}','👍',${isGroup})">👍</button>
+          <button class="text-sm" onclick="addReaction('${id}','❤️',${isGroup})">❤️</button>
+          <button class="text-sm" onclick="addReaction('${id}','😂',${isGroup})">😂</button>
+        `;
+      }
+
+      async function addReaction(id, emoji, isGroup = false) {
+        const table = isGroup
+          ? "group_message_reactions"
+          : "direct_message_reactions";
+        await supabase.from(table).insert({
+          message_id: id,
+          user_id: currentUser.id,
+          reaction: emoji,
+        });
+
+        const msg = (currentMessages || []).find((m) => m.id === id);
+        if (msg) {
+          const targetId = isGroup ? msg.user_id : msg.sender_id;
+          if (targetId !== currentUser.id) {
+            await supabase.from("notifications").insert({
+              user_id: targetId,
+              type: "reaction",
+              title: "リアクション",
+              content: `${userProfile.last_name} ${userProfile.first_name}さんがあなたのメッセージにリアクションしました`,
+              related_id: id,
+            });
+          }
+        }
+
+        if (isGroup) {
+          await loadGroupMessages(currentGroup.id);
+        } else {
+          await loadMessages(currentChatUser.id);
+        }
+      }
+
       function scrollToBottom() {
         const container = document.getElementById("messages-container");
         container.scrollTop = container.scrollHeight;
@@ -1594,6 +1665,19 @@
             this.value = "";
           }
         });
+
+      document
+        .getElementById("sticker-btn")
+        .addEventListener("click", function () {
+          document.getElementById("sticker-panel").classList.toggle("hidden");
+        });
+
+      document.querySelectorAll(".sticker-option").forEach((img) => {
+        img.addEventListener("click", () => {
+          document.getElementById("sticker-panel").classList.add("hidden");
+          sendMessage("", img.src);
+        });
+      });
 
       // 通話関連
       document

--- a/supabase/migrations/20250618_add_message_reactions.sql
+++ b/supabase/migrations/20250618_add_message_reactions.sql
@@ -1,0 +1,20 @@
+-- Add tables for message reactions
+CREATE TABLE IF NOT EXISTS public.group_message_reactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id uuid REFERENCES public.group_messages(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reaction text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_gm_reactions_message ON public.group_message_reactions(message_id);
+CREATE INDEX IF NOT EXISTS idx_gm_reactions_user ON public.group_message_reactions(user_id);
+
+CREATE TABLE IF NOT EXISTS public.direct_message_reactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id uuid REFERENCES public.direct_messages(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reaction text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_dm_reactions_message ON public.direct_message_reactions(message_id);
+CREATE INDEX IF NOT EXISTS idx_dm_reactions_user ON public.direct_message_reactions(user_id);


### PR DESCRIPTION
## Summary
- create schema tables for message reactions
- provide SQL migration for message reactions
- enable reactions and sticker UI in direct and group chats
- embed stickers using base64 instead of binary files

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850f1357b3883309295c06e1db53656