### PR TITLE
Implement posting feature with image uploads

### DIFF
--- a/__tests__/post.test.js
+++ b/__tests__/post.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+import { createPost } from '../js/post.js';
+
+test('createPost uploads images and inserts row', async () => {
+  const upload = jest.fn().mockResolvedValue({ error: null });
+  const getPublicUrl = jest.fn((path) => ({ data: { publicUrl: `https://cdn/${path}` } }));
+  const insert = jest.fn().mockReturnThis();
+  const select = jest.fn().mockReturnThis();
+  const single = jest.fn().mockResolvedValue({ data: { id: 'p1' }, error: null });
+
+  const supabase = {
+    auth: { getUser: async () => ({ data: { user: { id: 'u1' } } }) },
+    storage: { from: () => ({ upload, getPublicUrl }) },
+    from: () => ({ insert, select, single }),
+  };
+
+  const files = [{ name: 'a.png' }];
+  const post = await createPost(supabase, 'hello', files);
+  expect(post).toEqual({ id: 'p1' });
+  expect(upload).toHaveBeenCalled();
+  const inserted = insert.mock.calls[0][0];
+  expect(inserted.user_id).toBe('u1');
+  expect(inserted.content).toBe('hello');
+  expect(Array.isArray(inserted.image_urls)).toBe(true);
+});
+
+test('createPost throws when not authenticated', async () => {
+  const supabase = { auth: { getUser: async () => ({ data: { user: null } }) } };
+  await expect(createPost(supabase, 'hi')).rejects.toThrow('not authenticated');
+});

--- a/dashboard.html
+++ b/dashboard.html
@@ -50,8 +50,10 @@
     <script type="module">
       import { showToast } from "./js/toast.js";
       import { registerPush } from "./js/push.js";
+      import { createPost } from "./js/post.js";
       window.showToast = showToast;
       window.registerPush = registerPush;
+      window.createPost = createPost;
     </script>
   </head>
   <body class="bg-gray-50 dark:bg-dark-bg dark:text-dark-text min-h-screen">
@@ -337,6 +339,28 @@
           <div class="px-6 py-4 border-b border-gray-200">
             <h2 class="text-lg font-semibold text-gray-800">最近の投稿</h2>
           </div>
+          <div class="px-6 py-4 space-y-2 border-b border-gray-200">
+            <textarea
+              id="post-content"
+              class="w-full border rounded p-2"
+              rows="3"
+              maxlength="280"
+              placeholder="今どうしてる？"
+            ></textarea>
+            <input
+              id="post-images"
+              type="file"
+              accept="image/*"
+              multiple
+              class="block"
+            />
+            <div class="text-right">
+              <button
+                id="post-submit"
+                class="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+              >投稿</button>
+            </div>
+          </div>
           <div id="dashboard-posts" class="divide-y divide-gray-200">
             <div class="px-6 py-8 text-center text-gray-500 skeleton">
               <div class="h-4 bg-gray-200 rounded w-3/4 mx-auto mb-2"></div>
@@ -547,6 +571,9 @@
 
         await checkAuth();
         await loadDashboardData();
+        document
+          .getElementById("post-submit")
+          ?.addEventListener("click", handleCreatePost);
         setupRealtimeSubscriptions();
 
         if (window.registerPush && window.__ENV__ && window.__ENV__.PUSH_VAPID_PUBLIC_KEY) {
@@ -1083,6 +1110,35 @@
                 </div>`;
           })
           .join("");
+      }
+
+      const MAX_TEXT = 280;
+      const MAX_IMAGES = 4;
+
+      async function handleCreatePost() {
+        const contentEl = document.getElementById("post-content");
+        const filesEl = document.getElementById("post-images");
+        const content = contentEl.value.trim();
+        const files = Array.from(filesEl.files || []);
+        if (content.length === 0 && files.length === 0) return;
+        if (content.length > MAX_TEXT) {
+          window.showToast && window.showToast(`最大${MAX_TEXT}文字までです`, "error");
+          return;
+        }
+        if (files.length > MAX_IMAGES) {
+          window.showToast && window.showToast(`画像は${MAX_IMAGES}枚までです`, "error");
+          return;
+        }
+        try {
+          await window.createPost(supabase, content, files);
+          contentEl.value = "";
+          filesEl.value = "";
+          await loadPosts();
+          window.showToast && window.showToast("投稿しました", "success");
+        } catch (e) {
+          console.error(e);
+          window.showToast && window.showToast("投稿に失敗しました", "error");
+        }
       }
 
       // 統計情報読み込み

--- a/js/post.js
+++ b/js/post.js
@@ -1,0 +1,30 @@
+export async function createPost(supabase, content, files = []) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('not authenticated');
+
+  const imageUrls = [];
+  for (const file of files) {
+    const ext = file.name ? file.name.split('.').pop() : 'png';
+    const fileName = `${user.id}_${Date.now()}_${Math.random()
+      .toString(36)
+      .slice(2)}.${ext}`;
+    const { error: uploadError } = await supabase.storage
+      .from('post-images')
+      .upload(fileName, file);
+    if (uploadError) throw uploadError;
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from('post-images').getPublicUrl(fileName);
+    imageUrls.push(publicUrl);
+  }
+
+  const { data, error } = await supabase
+    .from('posts')
+    .insert({ user_id: user.id, content, image_urls: imageUrls })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}

--- a/posts.html
+++ b/posts.html
@@ -19,6 +19,12 @@
         font-family: "Noto Sans JP", sans-serif;
       }
     </style>
+    <script type="module">
+      import { showToast } from "./js/toast.js";
+      import { createPost } from "./js/post.js";
+      window.showToast = showToast;
+      window.createPost = createPost;
+    </script>
   </head>
   <body class="bg-gray-50 min-h-screen">
     <div id="header-placeholder"></div>
@@ -26,6 +32,28 @@
 
     <main class="max-w-3xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
       <h1 class="text-2xl font-bold text-gray-800 mb-6">投稿一覧</h1>
+      <div class="bg-white rounded-lg shadow-sm p-4 mb-4 space-y-2">
+        <textarea
+          id="post-content"
+          class="w-full border rounded p-2"
+          rows="3"
+          maxlength="280"
+          placeholder="今どうしてる？"
+        ></textarea>
+        <input
+          id="post-images"
+          type="file"
+          accept="image/*"
+          multiple
+          class="block"
+        />
+        <div class="text-right">
+          <button
+            id="post-submit"
+            class="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+          >投稿</button>
+        </div>
+      </div>
       <div id="posts-container" class="bg-white rounded-lg divide-y divide-gray-200">
         <div class="px-6 py-8 text-center text-gray-500">
           <div class="h-4 bg-gray-200 rounded w-3/4 mx-auto mb-2"></div>
@@ -48,6 +76,9 @@
         pageUser = params.get("user");
         await checkAuth();
         await loadPosts();
+        document
+          .getElementById("post-submit")
+          ?.addEventListener("click", handleCreatePost);
       });
 
       async function checkAuth() {
@@ -116,6 +147,35 @@
           </div>`;
           })
           .join("");
+      }
+
+      const MAX_TEXT = 280;
+      const MAX_IMAGES = 4;
+
+      async function handleCreatePost() {
+        const contentEl = document.getElementById("post-content");
+        const filesEl = document.getElementById("post-images");
+        const content = contentEl.value.trim();
+        const files = Array.from(filesEl.files || []);
+        if (content.length === 0 && files.length === 0) return;
+        if (content.length > MAX_TEXT) {
+          window.showToast && window.showToast(`最大${MAX_TEXT}文字までです`, "error");
+          return;
+        }
+        if (files.length > MAX_IMAGES) {
+          window.showToast && window.showToast(`画像は${MAX_IMAGES}枚までです`, "error");
+          return;
+        }
+        try {
+          await window.createPost(supabase, content, files);
+          contentEl.value = "";
+          filesEl.value = "";
+          await loadPosts();
+          window.showToast && window.showToast("投稿しました", "success");
+        } catch (e) {
+          console.error(e);
+          window.showToast && window.showToast("投稿に失敗しました", "error");
+        }
       }
     </script>
     <script src="js/theme.js"></script>


### PR DESCRIPTION
## Summary
- add JS helper to create new posts with optional image uploads
- allow posting from dashboard and posts pages
- validate post length and image count
- reload feeds after posting
- test post creation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f59b15b48330af75639bd71efba8