### PR TITLE
Implement likes and bookmarks

### DIFF
--- a/js/post.js
+++ b/js/post.js
@@ -1,0 +1,71 @@
+export async function toggleLike(supabase, postId, userId) {
+  const { data: existing } = await supabase
+    .from('post_likes')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('post_id', postId)
+    .single();
+  let liked;
+  if (existing) {
+    await supabase.from('post_likes').delete().eq('id', existing.id);
+    liked = false;
+  } else {
+    await supabase.from('post_likes').insert({ user_id: userId, post_id: postId });
+    liked = true;
+  }
+
+  const { count } = await supabase
+    .from('post_likes')
+    .select('*', { count: 'exact', head: true })
+    .eq('post_id', postId);
+  await supabase.from('posts').update({ likes_count: count }).eq('id', postId);
+
+  return { liked, likesCount: count };
+}
+
+export async function toggleBookmark(supabase, postId, userId) {
+  const { data: existing } = await supabase
+    .from('post_bookmarks')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('post_id', postId)
+    .single();
+  if (existing) {
+    await supabase.from('post_bookmarks').delete().eq('id', existing.id);
+    return { bookmarked: false };
+  }
+  await supabase.from('post_bookmarks').insert({ user_id: userId, post_id: postId });
+  return { bookmarked: true };
+}
+
+export function updateLikeButton(button, liked) {
+  if (!button) return;
+  if (liked) {
+    button.textContent = 'いいね済み';
+    button.classList.add('text-blue-600');
+    button.classList.remove('text-gray-600');
+    button.setAttribute('aria-pressed', 'true');
+  } else {
+    button.textContent = 'いいね';
+    button.classList.remove('text-blue-600');
+    button.classList.add('text-gray-600');
+    button.setAttribute('aria-pressed', 'false');
+  }
+  button.disabled = false;
+}
+
+export function updateBookmarkButton(button, bookmarked) {
+  if (!button) return;
+  if (bookmarked) {
+    button.textContent = '保存済み';
+    button.classList.add('text-blue-600');
+    button.classList.remove('text-gray-600');
+    button.setAttribute('aria-pressed', 'true');
+  } else {
+    button.textContent = '保存';
+    button.classList.remove('text-blue-600');
+    button.classList.add('text-gray-600');
+    button.setAttribute('aria-pressed', 'false');
+  }
+  button.disabled = false;
+}

--- a/posts.html
+++ b/posts.html
@@ -36,9 +36,15 @@
 
     <div id="footer-placeholder"></div>
 
-    <script>
+    <script type="module">
       const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
       const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+      const {
+        toggleLike,
+        toggleBookmark,
+        updateLikeButton,
+        updateBookmarkButton,
+      } = await import('./js/post.js');
       let currentUser = null;
       let pageUser = null;
 
@@ -87,6 +93,22 @@
 
         const { data: posts } = await query.limit(20);
 
+        const { data: likedPosts } = await supabase
+          .from("post_likes")
+          .select("post_id")
+          .eq("user_id", currentUser.id);
+        const likedSet = new Set(
+          likedPosts ? likedPosts.map((p) => p.post_id) : []
+        );
+
+        const { data: bookmarkedPosts } = await supabase
+          .from("post_bookmarks")
+          .select("post_id")
+          .eq("user_id", currentUser.id);
+        const bookmarkedSet = new Set(
+          bookmarkedPosts ? bookmarkedPosts.map((b) => b.post_id) : []
+        );
+
         if (!posts || posts.length === 0) {
           container.innerHTML =
             '<div class="px-6 py-8 text-center text-gray-500"><p class="text-sm">まだ投稿がありません</p></div>';
@@ -98,8 +120,10 @@
             const images = (post.image_urls || [])
               .map((url) => `<img loading="lazy" src="${url}" class="mt-2 rounded-md">`)
               .join("");
+            const liked = likedSet.has(post.id);
+            const bookmarked = bookmarkedSet.has(post.id);
             return `
-          <div class="px-6 py-4">
+          <div class="px-6 py-4" data-id="${post.id}">
             <div class="flex items-start space-x-3">
               <img loading="lazy" class="h-8 w-8 rounded-full object-cover" src="${
                 post.profiles?.profile_image_url || "/api/placeholder/32/32"
@@ -111,11 +135,44 @@
                 <p class="whitespace-pre-wrap mt-1">${post.content}</p>
                 ${images}
                 <p class="text-xs text-gray-500 mt-1">${new Date(post.created_at).toLocaleString("ja-JP")}</p>
+                <div class="mt-2 flex items-center space-x-4 text-sm">
+                  <button class="like-btn ${liked ? 'text-blue-600' : 'text-gray-600'}" data-id="${post.id}" aria-pressed="${liked}">${liked ? 'いいね済み' : 'いいね'}</button>
+                  <span class="likes-count">${post.likes_count}</span>
+                  <button class="bookmark-btn ${bookmarked ? 'text-blue-600' : 'text-gray-600'}" data-id="${post.id}" aria-pressed="${bookmarked}">${bookmarked ? '保存済み' : '保存'}</button>
+                </div>
               </div>
             </div>
           </div>`;
           })
           .join("");
+
+        container.querySelectorAll('.like-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            const postId = btn.dataset.id;
+            const countEl = btn.parentElement.querySelector('.likes-count');
+            const { liked, likesCount } = await toggleLike(
+              supabase,
+              postId,
+              currentUser.id
+            );
+            updateLikeButton(btn, liked);
+            if (countEl) countEl.textContent = likesCount;
+          });
+        });
+
+        container.querySelectorAll('.bookmark-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            const postId = btn.dataset.id;
+            const { bookmarked } = await toggleBookmark(
+              supabase,
+              postId,
+              currentUser.id
+            );
+            updateBookmarkButton(btn, bookmarked);
+          });
+        });
       }
     </script>
     <script src="js/theme.js"></script>

--- a/profile-detail.html
+++ b/profile-detail.html
@@ -391,7 +391,7 @@
   document.write(fXhr.responseText);
 </script>
 
-    <script>
+    <script type="module">
       // Supabase設定
       const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.__ENV__;
       const supabase = window.supabase.createClient(
@@ -407,6 +407,13 @@
         cancelFollowRequest,
         updateFollowButton,
       } = await import('./js/follow.js');
+
+      const {
+        toggleLike,
+        toggleBookmark,
+        updateLikeButton,
+        updateBookmarkButton,
+      } = await import('./js/post.js');
 
       // グローバル変数
       let currentUser = null;
@@ -1132,6 +1139,20 @@
           .order("created_at", { ascending: false })
           .limit(10);
 
+        const { data: likedPosts } = await supabase
+          .from("post_likes")
+          .select("post_id")
+          .eq("user_id", currentUser.id);
+        const likedSet = new Set(likedPosts ? likedPosts.map((p) => p.post_id) : []);
+
+        const { data: bookmarkedPosts } = await supabase
+          .from("post_bookmarks")
+          .select("post_id")
+          .eq("user_id", currentUser.id);
+        const bookmarkedSet = new Set(
+          bookmarkedPosts ? bookmarkedPosts.map((b) => b.post_id) : []
+        );
+
         const container = document.getElementById("posts-content");
         if (!posts || posts.length === 0) {
           container.innerHTML = `<svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg><p class="mt-2 text-sm">投稿情報はまだありません</p>`;
@@ -1162,16 +1183,21 @@
               `
               )
               .join("");
+            const liked = likedSet.has(post.id);
+            const bookmarked = bookmarkedSet.has(post.id);
             return `
-              <div class="border-b border-gray-200 py-4">
+              <div class="border-b border-gray-200 py-4" data-id="${post.id}">
                 <p class="whitespace-pre-wrap">${post.content}</p>
                 ${images}
                 <div class="text-sm text-gray-500 mt-1">${new Date(
                   post.created_at
                 ).toLocaleString("ja-JP")}</div>
-                <div class="text-sm text-gray-600 mt-1">いいね ${
-                  post.likes_count
-                } ・ コメント ${post.comments_count}</div>
+                <div class="text-sm text-gray-600 mt-1 flex items-center space-x-4">
+                  <button class="like-btn ${liked ? 'text-blue-600' : 'text-gray-600'}" data-id="${post.id}" aria-pressed="${liked}">${liked ? 'いいね済み' : 'いいね'}</button>
+                  <span class="likes-count">${post.likes_count}</span>
+                  <span>コメント ${post.comments_count}</span>
+                  <button class="bookmark-btn ${bookmarked ? 'text-blue-600' : 'text-gray-600'}" data-id="${post.id}" aria-pressed="${bookmarked}">${bookmarked ? '保存済み' : '保存'}</button>
+                </div>
                 <div class="mt-2">${comments}</div>
               </div>`;
           })
@@ -1179,6 +1205,34 @@
 
         container.classList.remove("text-center", "text-gray-500", "py-8");
         container.innerHTML = html;
+
+        container.querySelectorAll('.like-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            const postId = btn.dataset.id;
+            const countEl = btn.parentElement.querySelector('.likes-count');
+            const { liked, likesCount } = await toggleLike(
+              supabase,
+              postId,
+              currentUser.id
+            );
+            updateLikeButton(btn, liked);
+            if (countEl) countEl.textContent = likesCount;
+          });
+        });
+
+        container.querySelectorAll('.bookmark-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            const postId = btn.dataset.id;
+            const { bookmarked } = await toggleBookmark(
+              supabase,
+              postId,
+              currentUser.id
+            );
+            updateBookmarkButton(btn, bookmarked);
+          });
+        });
       }
 
       // フォロー/アンフォロー処理


### PR DESCRIPTION
## Summary
- create `js/post.js` with helpers to like or bookmark posts
- update `posts.html` to show like and bookmark buttons and reflect counts
- enhance `profile-detail.html` with same post interaction controls

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: no ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6850f59c8f34833083fcf52c5a5982e3