### PR TITLE
Update follow request filtering

### DIFF
--- a/connections.html
+++ b/connections.html
@@ -152,7 +152,8 @@
         const { data } = await supabase
           .from('follow_requests')
           .select('target_id')
-          .eq('requester_id', currentUser.id);
+          .eq('requester_id', currentUser.id)
+          .eq('status', 'pending');
         followRequestSet = new Set((data || []).map((r) => r.target_id));
       }
 

--- a/search.html
+++ b/search.html
@@ -1038,7 +1038,8 @@
         const { data } = await supabase
           .from("follow_requests")
           .select("target_id")
-          .eq("requester_id", currentUser.id);
+          .eq("requester_id", currentUser.id)
+          .eq("status", "pending");
 
         if (data) {
           followRequests = new Set(data.map((r) => r.target_id));


### PR DESCRIPTION
## Summary
- filter `loadFollowRequests` results so only `pending` status requests populate
  - update in `connections.html`
  - update in `search.html`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851064670d08330b1de1c5d8aced8bb