### PR TITLE
Generate config.js at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
 legacy/
+
+config.js

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ AI-powered matching to streamline building a startup team.
 
 ## Setup
 
-1. Create a `.env` file with your Supabase and OpenAI credentials:
+1. Create a `.env` file with your Supabase and OpenAI credentials. The previous
+   Supabase key has been revoked; store your new credentials **only** in this file:
 
    ```env
    SUPABASE_URL=<your-supabase-url>
@@ -16,11 +17,15 @@ AI-powered matching to streamline building a startup team.
    To enable optional push notifications, also provide `PUSH_VAPID_PUBLIC_KEY`
    and `PUSH_VAPID_PRIVATE_KEY`.
 
-2. Generate `config.js` from the template:
+2. Run the build script to generate `config.js`:
 
    ```bash
-    npm run build
-    ```
+   npm run build
+   ```
+
+   This executes `generate-config.js`, which reads the values from `.env` and
+   writes a `config.js` file. The generated file is ignored by Git and must be
+   regenerated whenever environment variables change.
 
 3. *(Optional)* Build ES5-compatible scripts for older browsers:
 

--- a/config.js
+++ b/config.js
@@ -1,5 +1,0 @@
-// config.template.js
-window.__ENV__ = {
-  SUPABASE_URL: 'https://jcyvpbfxkpogbceorgqi.supabase.co',
-  SUPABASE_ANON_KEY: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpjeXZwYmZ4a3BvZ2JjZW9yZ3FpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5OTI4NzAsImV4cCI6MjA2NTU2ODg3MH0.eGn205pY9r-6ghcZB_8AGQeYqSHvfy4Tvx89ntFw_iw'
-};


### PR DESCRIPTION
## Summary
- remove committed `config.js` and add it to `.gitignore`
- document building `config.js` via `generate-config.js` using `.env`
- ensure Supabase keys live only in `.env`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aa7c7d2f08330bf74804638db5727