### PR TITLE
Handle edge cases in cosine similarity

### DIFF
--- a/__tests__/cosineSimilarity.test.js
+++ b/__tests__/cosineSimilarity.test.js
@@ -1,0 +1,19 @@
+let cosineSimilarity;
+
+beforeAll(async () => {
+  process.env.SUPABASE_URL = 'http://example.com';
+  process.env.SUPABASE_ANON_KEY = 'test-key';
+  process.env.OPENAI_API_KEY = 'test-key';
+  ({ cosineSimilarity } = await import('../server.js'));
+});
+
+describe('cosineSimilarity', () => {
+  test('returns 0 when either vector has zero norm', () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+    expect(cosineSimilarity([0, 0], [0, 0])).toBe(0);
+  });
+
+  test('throws error when vector lengths differ', () => {
+    expect(() => cosineSimilarity([1, 2], [1, 2, 3])).toThrow('Vector length mismatch');
+  });
+});

--- a/server.js
+++ b/server.js
@@ -64,7 +64,10 @@ app.post('/api/compute_embedding', async (req, res) => {
   }
 });
 
-function cosineSimilarity(a, b) {
+export function cosineSimilarity(a, b) {
+  if (a.length !== b.length) {
+    throw new Error('Vector length mismatch');
+  }
   let dot = 0;
   let normA = 0;
   let normB = 0;
@@ -73,6 +76,7 @@ function cosineSimilarity(a, b) {
     normA += a[i] * a[i];
     normB += b[i] * b[i];
   }
+  if (normA === 0 || normB === 0) return 0;
   return dot / (Math.sqrt(normA) * Math.sqrt(normB));
 }
 
@@ -153,6 +157,10 @@ app.post('/mark_notification', async (req, res) => {
 });
 
 const port = process.env.PORT || 3001;
-app.listen(port, () => {
-  console.log(`Embedding service running on port ${port}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Embedding service running on port ${port}`);
+  });
+}
+
+export default app;


### PR DESCRIPTION
## Summary
- validate input length and handle zero-vector division in `cosineSimilarity`
- avoid starting Express server in tests
- add tests for zero-vector and mismatched length cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aa7ca5abc8330b440b982d54ecb69